### PR TITLE
DisplayLink guard tests + testing strategy docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,19 @@ Run tests with `./run-tests.sh` which:
 4. Runs formatting and linting checks
 5. Checks for uncommitted generated files
 
-Individual test suites in `Sources/AppBundleTests/` covering tree operations, config parsing, shell parsing, and command execution.
+> **Toolchain:** tests build against the macOS SDK, so on a beta macOS use the matching
+> Xcode beta or `swift test` may hang silently. Run:
+> `DEVELOPER_DIR=/Applications/Xcode-27.0.0-Beta.2.app/Contents/Developer xcrun swift test`
+
+The suite (~98 XCTest functions in `Sources/AppBundleTests/`) is fully headless — it
+uses a fake window tree (`TestApp`/`TestWindow`) and a mock Accessibility layer
+(`AxUiElementMock` + captured `axDumps/` fixtures), so it needs no real windows or
+Accessibility permission. It covers tree operations, command logic, config parse/round-trip,
+window-kind heuristics, socket codec, and DisplayLink monitor-fingerprint (UUID) matching.
+
+See **`dev-docs/testing-strategy.md`** for the full long-term plan: coverage gaps, the
+seams to add for headless layout/multi-monitor testing, the live-app e2e harness,
+CI strategy, and the DisplayLink testing story.
 
 ## Common Gotchas
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ aerospork --help                      # Show all commands
 ./format.sh                   # Format code with swiftformat
 ```
 
+The test suite is headless (fake window tree + mock Accessibility layer), so it needs
+no real windows or permissions. On a beta macOS, use the matching Xcode beta toolchain
+or the build can hang:
+`DEVELOPER_DIR=/Applications/Xcode-27.0.0-Beta.2.app/Contents/Developer xcrun swift test`.
+See `dev-docs/testing-strategy.md` for the long-term testing plan.
+
 ### Project Structure
 
 ```

--- a/Sources/AppBundleTests/assert.swift
+++ b/Sources/AppBundleTests/assert.swift
@@ -6,6 +6,10 @@ func assertTrue(_ actual: Bool, file: String = #filePath, line: Int = #line) {
     assertEquals(actual, true, file: file, line: line)
 }
 
+func assertFalse(_ actual: Bool, file: String = #filePath, line: Int = #line) {
+    assertEquals(actual, false, file: file, line: line)
+}
+
 // Because assertEquals default messages are unreadable!
 func assertNotEquals<T>(_ actual: T, _ expected: T, file: String = #filePath, line: Int = #line) where T: Equatable {
     if actual == expected {

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -256,6 +256,36 @@ final class ConfigTest: XCTestCase {
         assertEquals([:], defaultConfig.workspaceToMonitorForceAssignment)
     }
 
+    /// DisplayLink: pin a workspace to a specific panel by its stable UUID.
+    func testParseWorkspaceToMonitorFingerprintUuid() {
+        let (parsed, errors) = parseConfigForTest(
+            """
+            [workspace-to-monitor-force-assignment]
+                dock = { fingerprint = { uuid = "37D8832A-2D66-02CA-B9F7-8F30A301B230" } }
+                ext = { fingerprint = { vendor = "0x1234", model = "0x5678" } }
+            """,
+        )
+        assertEquals([], errors.descriptions)
+        assertEquals(
+            [MonitorDescription.fingerprint(MonitorFingerprintPatternData(displayUUID: "37D8832A-2D66-02CA-B9F7-8F30A301B230"))],
+            parsed.workspaceToMonitorForceAssignment["dock"],
+        )
+        assertEquals(
+            [MonitorDescription.fingerprint(MonitorFingerprintPatternData(vendorID: 0x1234, modelID: 0x5678))],
+            parsed.workspaceToMonitorForceAssignment["ext"],
+        )
+    }
+
+    func testParseWorkspaceToMonitorFingerprintRejectsUnknownKey() {
+        let (_, errors) = parseConfigForTest(
+            """
+            [workspace-to-monitor-force-assignment]
+                x = { fingerprint = { bogus = "y" } }
+            """,
+        )
+        assertTrue(errors.descriptions.contains { $0.contains("bogus") })
+    }
+
     func testParseOnWindowDetected() {
         let (_, errors) = parseConfigForTest(
             """

--- a/Sources/AppBundleTests/model/MonitorFingerprintTest.swift
+++ b/Sources/AppBundleTests/model/MonitorFingerprintTest.swift
@@ -1,0 +1,90 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+/// Guards DisplayLink support: DisplayLink panels report nil vendor/model/serial and are otherwise
+/// indistinguishable, so aerospork pins workspaces to them by the stable per-display UUID
+/// (CGDisplayCreateUUIDFromDisplayID). These tests exercise the pure `matches(patternData:)` logic
+/// that backs `[workspace-to-monitor-force-assignment]` fingerprint resolution.
+@MainActor
+final class MonitorFingerprintTest: XCTestCase {
+    // MARK: - UUID matching (the DisplayLink discriminator)
+
+    func testUuidMatchesCaseInsensitively() {
+        let fp = MonitorFingerprint(displayUUID: "37D8832A-2D66-02CA-B9F7-8F30A301B230")
+        assertTrue(fp.matches(patternData: pattern(uuid: "37D8832A-2D66-02CA-B9F7-8F30A301B230")))
+        assertTrue(fp.matches(patternData: pattern(uuid: "37d8832a-2d66-02ca-b9f7-8f30a301b230")))
+    }
+
+    func testUuidMismatchDoesNotMatch() {
+        let fp = MonitorFingerprint(displayUUID: "37D8832A-2D66-02CA-B9F7-8F30A301B230")
+        assertFalse(fp.matches(patternData: pattern(uuid: "00000000-0000-0000-0000-000000000000")))
+    }
+
+    func testUuidPatternRequiresMonitorUuid() {
+        // A monitor with no UUID must never match a UUID-specified pattern.
+        let fp = MonitorFingerprint(displayName: "Some Display", displayUUID: nil)
+        assertFalse(fp.matches(patternData: pattern(uuid: "37D8832A-2D66-02CA-B9F7-8F30A301B230")))
+    }
+
+    /// The core DisplayLink case: two panels from the same dock report identical (nil) vendor/model/
+    /// serial and the same name + resolution. Only the UUID tells them apart — each `uuid=` pattern
+    /// must match exactly one panel, so two workspaces don't collapse onto the same monitor.
+    func testTwoIdenticalDisplayLinkPanelsDisambiguatedByUuid() {
+        let uuidA = "AAAAAAAA-0000-0000-0000-000000000001"
+        let uuidB = "BBBBBBBB-0000-0000-0000-000000000002"
+        let panelA = MonitorFingerprint(vendorID: nil, modelID: nil, serialNumber: nil,
+                                        displayName: "DisplayLink Display", widthPixels: 1920, heightPixels: 1080, displayUUID: uuidA)
+        let panelB = MonitorFingerprint(vendorID: nil, modelID: nil, serialNumber: nil,
+                                        displayName: "DisplayLink Display", widthPixels: 1920, heightPixels: 1080, displayUUID: uuidB)
+
+        assertTrue(panelA.matches(patternData: pattern(uuid: uuidA)))
+        assertFalse(panelA.matches(patternData: pattern(uuid: uuidB)))
+        assertTrue(panelB.matches(patternData: pattern(uuid: uuidB)))
+        assertFalse(panelB.matches(patternData: pattern(uuid: uuidA)))
+
+        // Name+resolution alone cannot disambiguate them (both match) — which is exactly why UUID exists.
+        assertTrue(panelA.matches(patternData: pattern(name: "DisplayLink Display")))
+        assertTrue(panelB.matches(patternData: pattern(name: "DisplayLink Display")))
+    }
+
+    // MARK: - Backward compatibility (the pre-UUID matching that already worked)
+
+    func testNameExactAndSubstringMatch() {
+        let fp = MonitorFingerprint(displayName: "Built-in Retina Display")
+        assertTrue(fp.matches(patternData: pattern(name: "Built-in Retina Display"))) // exact, case-insensitive
+        assertTrue(fp.matches(patternData: pattern(name: "built-in retina display")))
+        assertTrue(fp.matches(patternData: pattern(name: "Retina"))) // substring
+        assertFalse(fp.matches(patternData: pattern(name: "External")))
+    }
+
+    func testVendorModelSerialMatch() {
+        let fp = MonitorFingerprint(vendorID: 0x1234, modelID: 0x5678, serialNumber: "ABC123", displayName: "Dell")
+        assertTrue(fp.matches(patternData: pattern(vendor: 0x1234, model: 0x5678, serial: "ABC123")))
+        assertFalse(fp.matches(patternData: pattern(vendor: 0x9999)))
+        assertFalse(fp.matches(patternData: pattern(serial: "WRONG")))
+    }
+
+    func testWidthHeightMatch() {
+        let fp = MonitorFingerprint(displayName: "X", widthPixels: 3840, heightPixels: 2160)
+        assertTrue(fp.matches(patternData: pattern(width: 3840, height: 2160)))
+        assertFalse(fp.matches(patternData: pattern(width: 1920)))
+    }
+
+    func testEmptyPatternMatchesAnything() {
+        // A pattern that constrains nothing matches every monitor (no fields to disqualify).
+        assertTrue(MonitorFingerprint(displayName: "Anything").matches(patternData: pattern()))
+    }
+
+    // MARK: - Helper
+
+    private func pattern(
+        vendor: UInt32? = nil, model: UInt32? = nil, serial: String? = nil,
+        name: String? = nil, width: Int? = nil, height: Int? = nil, uuid: String? = nil
+    ) -> MonitorFingerprintPatternData {
+        MonitorFingerprintPatternData(
+            vendorID: vendor, modelID: model, serialNumber: serial,
+            displayNamePattern: name, widthPixels: width, heightPixels: height, displayUUID: uuid,
+        )
+    }
+}

--- a/dev-docs/testing-strategy.md
+++ b/dev-docs/testing-strategy.md
@@ -1,0 +1,344 @@
+# aerospork Testing Strategy
+
+A long-term plan for testing a macOS tiling window manager: what to test, how to
+test the hard parts (real windows, multi-monitor, DisplayLink) without flaking,
+and the tooling/skills to build and maintain to keep it honest over time.
+
+> **Toolchain gotcha, read first.** This app is bound to the macOS SDK, not just a
+> Swift version. On macOS 27 the only working toolchain is Xcode 27 beta 2 (Swift
+> 6.4); a mismatched SDK makes `swift build` **hang silently**. Every build/test
+> script must preflight the toolchain (see §8). Build/test with:
+> ```
+> DEVELOPER_DIR=/Applications/Xcode-27.0.0-Beta.2.app/Contents/Developer xcrun swift test
+> ```
+
+---
+
+## 1. Where we are today
+
+**Good news — this is not a greenfield.** The upstream AeroSpace test design is
+headless and reusable:
+
+- **~98 XCTest functions** across `Sources/AppBundleTests/`, all headless (incl. new
+  DisplayLink monitor-fingerprint/UUID guard tests).
+- **A fake-tree seam**: `AbstractApp`/`TestApp`, `Window`(class)/`TestWindow`,
+  `Monitor`(protocol)/`MonitorImpl`. Tests build a *real* `Workspace`/`TilingContainer`
+  tree out of `TestWindow.new(...)`, run *real* `Command` objects, and assert on
+  `layoutDescription` (a structural snapshot). Tree mutation, focus order,
+  normalization, split/join/move/resize are all exercised with no real windows.
+- **An AX read seam**: `protocol AxUiElementMock` (`get` + `containingWindowId`) with a
+  real `AXUIElement` conformance and a `[String: Json]` fake. `AxWindowKindTest` replays
+  **61 captured real-window AX dumps** from `axDumps/*.json5` through the window-kind
+  heuristics — genuinely headless classification regression tests.
+- **A machine-readable control/observability surface**: a socket-speaking CLI
+  (`.debug/aerospork`), `--json` on `list-windows`/`list-workspaces`/`list-monitors`,
+  rich `--format` vars, and `trigger-binding`/`enable` for driving the live app.
+- **`run-tests.sh`** already does build → `swift test` → CLI smoke → format/lint →
+  generate → uncommitted-file check. **It is a CI job body with no CI calling it.**
+
+**The real gaps:**
+
+1. **No CI at all** (`.github/` absent). `run-tests.sh` runs only when a human runs it.
+2. **The fork's marquee new code is untested.** `ConfigurationWriter` (line-surgery TOML
+   editing) and the settings GUI are guarded only by `test-settings-ui.sh` — a *manual,
+   interactive* checklist whose Test 1 is "did keybindings survive a Save?" i.e. a real
+   data-loss bug now guarded by a human pressing Enter. Same for the other revamp code:
+   `UnixSocket` framing, `Key` Carbon mapping, `SystemVolume`, `MonitorFingerprint`
+   UUID matching, `ConfigFileWatcher` — **zero tests each.**
+3. **Layout geometry is unreachable in tests.** `layoutRecursive` computes each node's rect
+   and records it (`lastAppliedLayoutPhysicalRect`) *before* the AX write — but the write
+   (`TestWindow.setAxFrame`) inherits `Window`'s `die("Not implemented")`, so no test can
+   call `layoutWorkspace()`. The math is pure and the answer is already on the node; one
+   override unlocks it (§4).
+4. **No live-app integration test exists.** Every test is in-process. `ClientServerTest`
+   only checks the JSON codec — it never binds a socket.
+5. **No window-geometry in the queryable surface** (see §7) — a product gap that limits
+   what e2e can assert without the unstable `debug-windows` output.
+
+---
+
+## 2. Test pyramid & cadence
+
+Push every bug **down** the pyramid when you fix it — most "window" bugs reproduce
+headless via the mock tree. A bug that only shows with a live socket is integration;
+only with real AX/monitors, e2e/manual.
+
+| Layer | What | Runs where | Cadence | Catches |
+|---|---|---|---|---|
+| **Static** | swiftformat, swiftlint, `generate.sh --all` + uncommitted check, **toolchain preflight** | Any Mac / CI | every commit | style drift, stale generated files, wrong-SDK builds |
+| **Unit (headless)** | existing tree/command/config/socket XCTest; **+ new** config round-trip/fuzz, socket framing, fingerprint/UUID, Key mapping; **+ layout golden-rects** (after §4 seam) | Any Mac / CI | every commit / PR | layout math, command logic, config parse+write data loss, window-kind heuristics, IPC framing |
+| **Integration (live socket/CLI)** | `run-e2e.sh`: launch debug app → `enable on` → issue commands → assert on `list-* --json` | self-hosted Mac (AX granted) | on merge + nightly | server/CLI wiring, framing over a real socket, refresh-session sync |
+| **E2E (real windows + virtual displays)** | spawn stock-app windows, tile, assert live rects; multi-monitor via BetterDisplay | self-hosted / dev Mac | nightly / on-demand | real AX quirks, tiling real windows, monitor arrangement, workspace assignment |
+| **Manual** | DisplayLink hardware (`uuid` fingerprint, flap timing), SwiftUI settings smoke, first-run permission UX | one dev Mac w/ dongle | per release | hardware-only fingerprinting, GUI regressions, permission flow |
+
+**CI feasibility (blunt):** ~80% of meaningful tests are headless and belong in CI.
+The AX/multi-monitor slice needs a real Mac; DisplayLink needs the physical dongle.
+GitHub-*hosted* runners can't even build this until a stable macOS-27 + Xcode-27 image
+ships — until then **CI = a self-hosted Mac on the pinned beta** running `run-tests.sh`.
+
+---
+
+## 3. Layer 1 — Unit test gaps (headless, do these first)
+
+All items below have **zero** current coverage (grep-confirmed) unless noted. None need
+a running app. Priority = value × cheapness.
+
+### P0 — cheap, high-value, no new seam
+
+| Test | Target | Why |
+|---|---|---|
+| **default-config parses** | `parseConfig(String(contentsOf: defaultConfigUrl), isUserConfig:false)` → `assertSucc` + spot-check values | Today it's only *implicitly* exercised (setUp `die()`s if it breaks). The shipped default must always parse; make it an explicit named guarantee. `config/Config.swift:23-38` |
+| **UnixSocket framing** | `sendMessage`/`recvMessage` loopback: empty / 1-byte / >64KiB payloads; `recvMessage` → nil on peer close; partial-read/EINTR via `socketpair(2)` into `UnixSocketConnection(fd:)` | Replaced BlueSocket; a framing bug = silent IPC corruption. `Common/util/UnixSocket.swift:40,60,85,93` |
+| **ConfigurationWriter round-trip + fuzz** | Feed base TOML (incl. `default-config.toml` and the keybinding/gaps cases from `test-settings-ui.sh`) through `write(from:)`, re-`parseConfig`; assert (a) managed keys changed, (b) comments/order/unknown sections survive, (c) `write→parse→write` is a fixed point. Add a small property fuzzer over valid VM states. | The marquee new code, a proven data-loss class, currently guarded by a human. **Retire `test-settings-ui.sh` Tests 1–2 into this.** `config/ConfigurationWriter.swift:57-194` |
+
+### P1 — cheap, protects the DisplayLink/hotkey revamp
+
+| Test | Target | Why |
+|---|---|---|
+| ✅ **MonitorFingerprint.matches(patternData:)** — *done, `MonitorFingerprintTest`* | UUID match/mismatch (case-insensitive), two identical DisplayLink panels disambiguated by UUID, name exact/substring, vendor/model/serial, width/height | UUID-first matching is the whole point of the DisplayLink work; pure `struct→Bool`. `model/MonitorFingerprint.swift:107-141` |
+| ✅ **Fingerprint config parse** — *done, `ConfigTest.testParseWorkspaceToMonitorFingerprintUuid`* | `parseConfig` of `[workspace-to-monitor-force-assignment]` with `fingerprint = { uuid = ... }`, hex `vendor='0x1234'`, and unknown-key rejection | The new fingerprint path was unasserted (`testParseWorkspaceToMonitorAssignment` covered only errors). `parseWorkspaceToMonitorAssignment.swift:49-118` |
+| **Key carbon/round-trip** | over `Key.allCases`: `toString()` reparses; spot-check `carbonKeyCode` for letters/digits/arrows | The soffes/HotKey → Carbon replacement is untested; a wrong keycode = a silently dead hotkey. `config/Key.swift` |
+
+### P2/P3 — needs a seam or is low-ROI
+
+- **Layout geometry** (gap math, accordion padding, fullscreen rect) — blocked on the §4
+  seam; then high-value golden-rect tests.
+- **ConfigurationViewModel** — separable logic testable; SwiftUI lifecycle is not.
+- **SystemVolume** (CoreAudio HW) and **ConfigFileWatcher** (DispatchSource timing) — Hard,
+  integration-style, low ROI; leave to the integration tier or skip.
+
+---
+
+## 4. Two small seams that unlock the hard layers
+
+These are the highest-leverage source changes — a few lines each, and they open up
+whole categories of headless tests.
+
+### Seam A — layout geometry (≈1–3 lines)
+
+`layoutRecursive` records each node's computed rect on the node *before* calling
+`window.setAxFrame` (`layout/layoutRecursive.swift:37-39`). On a `TestWindow` that write
+hits `Window`'s base `die("Not implemented")` and aborts the run.
+
+**Change:** override `setAxFrame` (and `setAxTopLeftCorner`/`getAxTopLeftCorner`/`getAxSize`
+for the floating path) in `TestWindow` to *record* the rect instead of dying (base
+`Window.setAxFrame` at `tree/Window.swift:53`).
+
+**Unlocks:** call `workspace.layoutWorkspace()` on a mock tree and assert every node's
+computed rect against expected pixels — tiles/gaps, accordion padding, fullscreen,
+multi-container nesting — all headless. Feeds the **layout golden-rect** tests (§10.4).
+The production no-op AX guard (`MacApp.setFrame`, reads a live element) stays Hard;
+that's fine, it's a thin wrapper the mock doesn't need.
+
+### Seam B — injectable monitors (small)
+
+`monitors`/`mainMonitor`/`sortedMonitors` (`model/Monitor.swift:101-115`) branch on
+`isUnitTest` and return a single hardcoded `testMonitor`. There's no way to hand tests a
+2- or 3-monitor arrangement, so multi-monitor and DisplayLink logic can't be constructed.
+
+**Change:** replace the `isUnitTest` branch with a settable `@MainActor var
+testMonitorsOverride: [Monitor]?` (nil ⇒ real NSScreen path). Add a `fingerprint`
+member to the `Monitor` protocol (default nil) so `resolveMonitor`'s `.fingerprint` path
+(`MonitorDescriptionEx.swift:12-18`) resolves against fakes.
+
+**Unlocks:** headless tests of workspace-to-monitor assignment, `move-node-to-monitor`,
+`move-workspace-to-monitor`, rearrange-on-config-change, and **the DisplayLink UUID
+matching path** — construct two identical fake monitors distinguished only by UUID and
+assert each `uuid=` assignment resolves to the right one.
+
+### Hygiene — reset leaking globals
+
+`setUpWorkspacesForTests` (`testUtil.swift:16-40`) never clears
+`currentlyManipulatedWithMouseWindowId` (read by layout) or `appForTests`. There's no
+`tearDown` anywhere. Add two resets so layout/mouse/monitor tests don't bleed across cases.
+
+---
+
+## 5. Layer 3 — Integration harness (`run-e2e.sh`)
+
+Drives the *live* app over the socket. Lives outside `run-tests.sh` (self-hosted/nightly
+tier). Bash is right — it's process orchestration, not logic.
+
+**Protocol facts** (for anyone hand-rolling; easiest is to just shell out to `.debug/aerospork`):
+- Socket: **`/tmp/com.wbs.aerospork.debug-<user>.sock`** for debug builds (`aeroSpaceAppId`
+  is `com.wbs.aerospork.debug` under `#if DEBUG`). Not `/tmp/aerospork-…`.
+- Framing: 4-byte big-endian length + JSON. `ClientRequest {args, stdin, command?}` →
+  `ServerAnswer {exitCode, stdout, stderr, serverVersionAndHash}` (`Common/model/clientServer.swift`).
+- **Server gate:** a disabled server rejects everything except `enable` — harness must
+  `aerospork enable on` first (`server.swift:58-65`).
+- **`exec-and-forget` is rejected over the socket.**
+- Useful drivers: `trigger-binding --mode <m> <binding>` (simulate a keybinding without
+  synthesizing key events), `reload-config`, `config`.
+
+**Harness flow:**
+```
+build-debug-app.sh                       # ad-hoc-signed .app so AX/didLaunch behave
+require-ax.sh                            # fail loud if Accessibility not granted (§10.6)
+open .debug/AeroSporkApp.app            # launch the menu-bar agent
+wait for /tmp/com.wbs.aerospork.debug-$USER.sock
+aerospork enable on
+open -na TextEdit ; open -na TextEdit    # spawn known windows
+ids=$(aerospork list-windows --all --app-bundle-id com.apple.TextEdit --json)
+aerospork focus / move / layout / split ...
+assert aerospork list-windows --workspace focused --json  == expected   # via jq
+teardown: aerospork enable off ; close spawned apps
+```
+Use a locked fixture `~/.aerospork-debug.toml` for determinism. Discover window ids from
+`list-windows --json`; drive/assert by `window-id`. Deterministic placement of a spawned
+window is best done with an `on-window-detected` config rule.
+
+---
+
+## 6. Layer 4/5 — Multi-monitor, DisplayLink, GUI
+
+**Multi-monitor (scriptable):** BetterDisplay 2 ships `betterdisplaycli` to create/remove
+virtual displays and toggle connect state — fully scriptable. Wrap it in
+`script/e2e/with-virtual-display.sh`. After create/destroy, sleep >250ms (the debounce)
+then assert via `list-monitors --json` and `list-workspaces --monitor N --json`. This
+exercises monitor count/arrangement changes, `autoMoveWorkspacesToAssignedMonitors`, and
+the signature-change gating in `GlobalObserver.onMonitorConfigurationChanged`.
+
+**DisplayLink (honest limits):**
+- The **debounce/rebalance plumbing** is testable with virtual displays (it only depends
+  on `didChangeScreenParameters`).
+- The **flap/settle burst timing** the 250ms debounce exists to absorb needs a **real
+  DisplayLink USB dock** — virtual displays fire one clean notification, not a burst.
+- The **`displayUUID` match on a real panel** (stable nil vendor/model/serial + persistent
+  UUID across reconnect) is hardware-only. Virtual displays *approximate* it (they have a
+  UUID) so the branch can be smoke-tested, but the UUID is runtime-assigned — a test must
+  read it back from `monitor-fingerprint` first, then verify a `uuid=` assignment.
+- Gate hardware tests behind `AEROSPORK_DISPLAYLINK=1` + a preflight that detects the panel;
+  otherwise skip with a logged reason. Keep a short manual DisplayLink checklist per release.
+
+**GUI:** the settings window's *logic* (round-trip) is covered headlessly by the
+ConfigurationWriter tests (§3). Visual/interaction smoke stays a per-release manual pass;
+don't invest in SwiftUI UI-automation — low ROI, high flake.
+
+---
+
+## 7. Product changes that make e2e assertions cleaner
+
+Small, also useful to end users, and they remove the biggest e2e friction:
+
+1. **Add `window-x` / `window-y` / `window-width` / `window-height` format vars** to
+   `FormatVar.WindowFormatVar` (`format.swift:77-81`). Today `list-windows` exposes only
+   id/fullscreen/title, so per-window tile geometry is **not** queryable — e2e must fall
+   back to `debug-windows --window-id` (explicitly "not stable API", not JSON, line-prefixed).
+   This one addition makes live rect assertions clean.
+2. **Add a `monitor-uuid` format var.** The DisplayLink UUID is currently only reachable
+   embedded in the `monitor-fingerprint` string; a test that builds a `uuid=` assignment
+   has to parse it out.
+
+Both are optional but recommended — they convert "parse an unstable debug dump" into
+"assert a JSON field."
+
+---
+
+## 8. Toolchain selection & preflight (the most-reused skill)
+
+The trap: `script/setup.sh`'s `swift()` wrapper runs `swiftly run swift` and
+`.swift-version` pins `6.2`; on macOS 27 that toolchain is broken and a mismatched SDK
+makes `swift build` **hang with no error**.
+
+**Recommendations:**
+1. **Pin the (OS, Xcode) pair, not just the Swift version** — a WM is bound to the SDK.
+   Resolve `DEVELOPER_DIR` from: env override → known install path → `xcode-select -p`.
+2. **Invert `setup.sh`:** prefer the pinned Xcode; use swiftly only as a fallback (today
+   swiftly-first is exactly what breaks).
+3. **Add a preflight (`script/preflight-toolchain.sh`)** that checks the SDK/Swift version
+   *before* building and hard-fails in ~1s with a readable message
+   (`"wrong SDK — expected Xcode 27 b2; run export DEVELOPER_DIR=…"`) instead of hanging.
+   **Wire it into every build/test/e2e script.** This is the highest-reuse maintenance skill.
+4. **CI:** set `DEVELOPER_DIR` in the workflow `env:` (cleaner than `sudo xcode-select`).
+
+---
+
+## 9. CI
+
+- **Add `.github/workflows/ci.yml`** that runs the existing `run-tests.sh` on a
+  **self-hosted macOS-27-beta runner** with `DEVELOPER_DIR` pinned in `env:`. Nearly all
+  value, almost no new code — the test body already exists.
+- Keep the toolchain pin in one place so the day a stable macOS-27 + Xcode-27 hosted image
+  lands, you flip one value and move to hosted runners.
+- CI runs: static + unit tiers on every PR; the integration tier (`run-e2e.sh`) on merge +
+  nightly on the self-hosted box where AX is granted once and persists.
+
+---
+
+## 10. Tooling / skills to build (catalog)
+
+Ordered by leverage. Ponytail bias: reuse `AxUiElementMock`, `run-tests.sh`, the XCTest
+harness, and the existing scripts (`build-debug-app.sh`,
+`reset-accessibility-permission-for-debug.sh`); add the minimum.
+
+1. **Toolchain preflight** — bash, `script/preflight-toolchain.sh`. §8. *Build first.*
+2. **CI workflow** — `.github/workflows/ci.yml` → `run-tests.sh` on self-hosted. §9. *Build first.*
+3. **ConfigurationWriter round-trip + fuzz** — XCTest,
+   `Sources/AppBundleTests/config/ConfigurationWriterTest.swift`. §3 P0. *Build first.*
+4. **Layout golden-rects** — extend XCTest under `Sources/AppBundleTests/layout/`, golden
+   JSON in `.../golden/`. Needs Seam A (§4). Snapshot computed rects for canonical trees
+   (h/v split, accordion, nested, 2-monitor); a diff is a layout regression, zero AX.
+5. **`run-e2e.sh` + `script/e2e/` helpers** — bash. §5. Integration tier.
+6. **`require-ax.sh`** — bash, `script/e2e/`. Check `AXIsProcessTrusted` for the debug
+   bundle; if not granted, print exact steps / open the pane and exit non-zero so e2e fails
+   loud instead of hanging on a permission dialog. Complements the existing reset script.
+   (You cannot auto-grant without MDM or SIP-off; on a dedicated self-hosted mini, grant
+   once — it persists. Document that one-time box setup.)
+7. **`with-virtual-display.sh`** — bash wrapper over `betterdisplaycli`. §6. Multi-monitor.
+8. **`capture-axdump.sh`** — bash, `script/`. Dump a focused window's AX tree to the
+   `Aero.*` JSON5 schema `AxWindowKindTest` expects, so refreshing a fixture is
+   `capture-axdump.sh chrome > axDumps/chrome.json5`. The `axDumps/` corpus rots as apps
+   update; add a short "how to add/refresh a fixture" doc.
+9. **Window-fixture spawner** — *defer.* Start with scripted stock apps (TextEdit/Terminal)
+   matched by title in `list-windows --json`. Only if that flakes, build a ~50-line
+   `TestWindowSpawner` helper that opens N titled `NSWindow`s from argv. YAGNI until stock
+   apps prove flaky.
+
+---
+
+## 11. Build-first roadmap
+
+**Phase 1 — headless value, no new seams (a day or two):**
+1. Toolchain preflight (`script/preflight-toolchain.sh`), wired into build/test scripts.
+2. `.github/workflows/ci.yml` → `run-tests.sh` on self-hosted.
+3. P0 unit tests: default-config parses, UnixSocket framing, **ConfigurationWriter
+   round-trip + fuzz** (retire `test-settings-ui.sh` Tests 1–2).
+4. P1 unit tests: ✅ MonitorFingerprint UUID matching + fingerprint config parse (done);
+   remaining — Key carbon mapping.
+
+**Phase 2 — unlock geometry & monitors (small seams):**
+5. Seam A (`TestWindow.setAxFrame` records rect) + layout golden-rect tests.
+6. Seam B (injectable monitors + `Monitor.fingerprint`) + multi-monitor / UUID-resolution
+   unit tests. Reset the two leaking globals in setUp.
+
+**Phase 3 — live integration:**
+7. `require-ax.sh` + `run-e2e.sh` (launch → enable → spawn → command → assert `--json`).
+8. (Optional product) add `window-x/y/width/height` + `monitor-uuid` format vars for clean
+   live rect assertions.
+9. `with-virtual-display.sh` for scripted multi-monitor e2e.
+
+**Phase 4 — maintenance skills & the tail:**
+10. `capture-axdump.sh` + fixture-refresh doc.
+11. Manual DisplayLink checklist (per release); GUI smoke checklist.
+12. Window-fixture spawner app — only if stock apps flake.
+
+**Highest leverage, if you do nothing else:** Phase 1 items 1–3. CI running the tests that
+already exist, a preflight that kills the silent hang, and automated coverage of the config
+writer that a human currently babysits.
+
+---
+
+## 12. Key references
+
+- Fake-tree seam: `Sources/AppBundleTests/tree/{TestApp,TestWindow,TilingContainer}.swift`,
+  `testUtil.swift`, `assert.swift`.
+- AX read seam: `Sources/AppBundle/util/AxUiElementMock.swift`, `accessibility.swift`,
+  `AxUiElementMockEx.swift`; fixtures in `axDumps/` driven by `AxWindowKindTest.swift`.
+- Layout seam point: `layout/layoutRecursive.swift:37-39`, `tree/Window.swift:53`.
+- Monitor seam point: `model/Monitor.swift:101-115`, `MonitorDescriptionEx.swift:12-18`.
+- Control channel: `server.swift`, `Cli/_main.swift`, `Common/util/UnixSocket.swift`,
+  `Common/model/clientServer.swift`; commands in `cmdArgsManifest.swift`; output vars in
+  `format.swift` / `formatToJson.swift`.
+- Scripts: `run-tests.sh`, `script/setup.sh`, `build-debug-app.sh`,
+  `script/reset-accessibility-permission-for-debug.sh`, `test-settings-ui.sh` (manual).
+- The `isUnitTest` master switch: `Common/util/commonUtil.swift:134`.


### PR DESCRIPTION
The DisplayLink guard tests and testing-strategy docs missed the #2 merge (it merged at the cleanup commit before these landed). This brings them into `main`.

## DisplayLink guard tests
Panels report nil vendor/model/serial and are pinned to workspaces by their stable `CGDisplayCreateUUIDFromDisplayID` UUID — logic that had **zero** coverage. `MonitorFingerprintTest` covers `matches(patternData:)` including two identical DisplayLink panels disambiguated only by UUID, plus backward-compat name/vendor-model-serial/resolution matching; `ConfigTest` covers fingerprint `uuid`/hex parse + unknown-key rejection. `assertFalse` helper added. **98 tests pass** (Xcode 27 beta 2). No production code changed.

## Docs
- New `dev-docs/testing-strategy.md`: long-term testing plan (coverage gaps, seams for headless layout/multi-monitor tests, live-app e2e harness, CI strategy, DisplayLink testing story, tooling to build).
- CLAUDE.md / README Testing sections: drop stale "shell parsing", note headless suite + Xcode-beta toolchain requirement, link the strategy doc.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)