### PR TITLE
Serve the update feed from aerospork.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,16 +163,16 @@ Download the notarized universal (arm64 + x86_64) build from the
 brew install --cask wbsmolen/tap/aerospork
 ```
 
-Both repositories are private during early release, so the cask and the release download both
-require an account with access.
+The tap is still private, so the cask currently needs an account with access. The releases on this
+repository are public, so the download above works for anyone.
 
-Installed copies check for updates themselves through
-[Sparkle](https://sparkle-project.org), against a signed appcast served from
-`agreeable-glacier-0a845c510.7.azurestaticapps.net`. Updates are verified against an EdDSA public
-key compiled into the app, so a build refuses anything it cannot verify. Automatic checking is off
-until you allow it; **Check for Updates…** in the menu bar checks on demand. There is no App Store
-update path to inherit, because the Accessibility APIs this app is built on do not work in a
-sandbox.
+Installed copies check for updates themselves through [Sparkle](https://sparkle-project.org),
+against a signed appcast served from
+[`aerospork.app/appcast.xml`](https://aerospork.app/appcast.xml). Updates are verified against an
+EdDSA public key compiled into the app, so a build refuses anything it cannot verify. Automatic
+checking is off until you allow it; **Check for Updates…** in the menu bar checks on demand. There
+is no App Store update path to inherit, because the Accessibility APIs this app is built on do not
+work in a sandbox.
 
 ## Configuration
 

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -9,7 +9,7 @@
 - `../Sources`.
   The majority of AeroSpork source code. Managed by SPM `../Package.swift`
 - `../Sources/AppBundle/`.
-  The aerospork.app server. An SPM library, exposed to the `aerosporkApp` executable target.
+  The AeroSpork.app server. An SPM library, exposed to the `aerosporkApp` executable target.
 - `../Sources/aerosporkApp/`.
   Thin app entry point (`@main`). SPM can't build a macOS App Bundle, so the release build is produced via the
   generated Xcode project. The Xcode project model lives in `../aerospork.xcodeproj/` and is generated from the
@@ -25,7 +25,7 @@
 
 ## client/server interaction
 
-`aerospork` CLI binary is client. `aerospork.app` is server. Client and server talk to each other via predefined UNIX file.
+`aerospork` CLI binary is client. `AeroSpork.app` is server. Client and server talk to each other via predefined UNIX file.
 
 Each time you run a CLI command:
 1. Args are parsed by the client, args parsing errors are reported if any. Help is shown if `-h`/`--help` is passed.

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -15,7 +15,7 @@ Skip what you already know.
 
 . Download the latest available zip from https://github.com/wbsmolen/aerospork/releases[releases page]
 . Unpack zip
-. Put unpacked `aerospork-v$VERSION/aerospork.app` to `/Applications`
+. Put unpacked `aerospork-v$VERSION/AeroSpork.app` to `/Applications`
 . Put unpacked `aerospork-v$VERSION/bin/aerospork` anywhere on `$PATH`
 (optional; needed only to drive AeroSpork from the CLI)
 
@@ -39,18 +39,18 @@ installation above. The release zip carries the same completions under
 If you see this message
 
 ----
-"aerospork.app" can't be opened because Apple cannot check it for malicious software.
+"AeroSpork.app" can't be opened because Apple cannot check it for malicious software.
 ----
 
 **Option 1** to resolve the problem
 
 ```
-xattr -d com.apple.quarantine /Applications/aerospork.app
+xattr -d com.apple.quarantine /Applications/AeroSpork.app
 ```
 
 **Option 2** to resolve the problem
 
-. Navigate in Finder to `/Applications/aerospork.app`
+. Navigate in Finder to `/Applications/AeroSpork.app`
 . Right click
 . Open
 
@@ -117,7 +117,7 @@ short file and assume the rest is inherited:
 
 [source,shell]
 ----
-cp /Applications/aerospork.app/Contents/Resources/default-config.toml ~/.aerospork.toml
+cp /Applications/AeroSpork.app/Contents/Resources/default-config.toml ~/.aerospork.toml
 ----
 
 link:config-examples/default-config.toml[Download default-config.toml]
@@ -206,7 +206,7 @@ If you use a different layout or alphabet, or want an alias for an existing key,
 
 The `exec` section configures the environment of `exec-*` commands and callbacks (such as xref:commands.adoc#exec-and-forget[exec-and-forget], <<exec-on-workspace-change-callback>>)
 
-* `exec.inherit-env-vars` controls whether `aerospork.app`'s own environment is inherited. The default is `true`
+* `exec.inherit-env-vars` controls whether `AeroSpork.app`'s own environment is inherited. The default is `true`
 * Override individual variables like this:
 +
 [source,toml]
@@ -845,7 +845,7 @@ aerospork config --config-path      # which file is actually loaded right now
 ----
 
 `--config-path` is the one to check first. If it prints a path *inside* the app bundle
-(`…/aerospork.app/Contents/Resources/default-config.toml`) then your config failed to load and
+(`…/AeroSpork.app/Contents/Resources/default-config.toml`) then your config failed to load and
 AeroSpork fell back to the built-in defaults. `reload-config --dry-run` will then tell you why.
 
 === Capturing logs

--- a/project.yml
+++ b/project.yml
@@ -102,7 +102,13 @@ targets:
         # of an EdDSA pair whose private half never leaves the release machine's login keychain;
         # Sparkle refuses any update it cannot verify against it, so the key is what makes the
         # channel safe, not the transport.
-        SUFeedURL: https://agreeable-glacier-0a845c510.7.azurestaticapps.net/appcast.xml
+        #
+        # This URL is baked into each build at compile time, so changing it only affects builds
+        # made after the change. Copies of 1.1.0 and earlier ask for
+        # agreeable-glacier-0a845c510.7.azurestaticapps.net, which is the Static Web App's own
+        # default hostname and cannot be removed while the app exists: it keeps answering, and
+        # those copies keep updating. Retiring the Static Web App would strand them.
+        SUFeedURL: https://aerospork.app/appcast.xml
         SUPublicEDKey: +/aLciv0lm3XT3X1XqxDZs2U6d0jbvL65PsPBCxGObA=
         # Checking is opt-in on first launch: Sparkle asks once rather than phoning home before
         # the user has agreed to it.

--- a/updates-site/README.md
+++ b/updates-site/README.md
@@ -1,0 +1,31 @@
+# updates-site
+
+What `https://aerospork.app` serves: the Sparkle appcast that installed copies poll, and a plain
+page explaining what the host is for. Two static files, no build step.
+
+## Why it is hosted separately
+
+`SUFeedURL` is compiled into the app, so the feed has to stay reachable for the lifetime of every
+build that carries it. Serving it from an Azure Static Web App rather than from this repository
+means it does not depend on the repository's visibility, its default branch, or GitHub Pages being
+configured. What makes the channel safe is `SUPublicEDKey`, not the transport: Sparkle refuses any
+update it cannot verify against that key.
+
+## Deploying
+
+```bash
+swa deploy updates-site \
+  --app-name aerospork-updates \
+  --resource-group aerospork-updates \
+  --env production
+```
+
+## The old hostname must keep answering
+
+Copies of 1.1.0 and earlier ask
+`agreeable-glacier-0a845c510.7.azurestaticapps.net` for their feed, because that is what was
+compiled into them. It is the Static Web App's own default hostname, so it answers as long as the
+app exists and serves the same content as `aerospork.app`. Deleting the Static Web App, or moving
+the feed to different infrastructure without leaving a redirect, strands every one of those
+installs on the version it already has, silently: Sparkle treats an unreachable feed as nothing to
+report.

--- a/updates-site/appcast.xml
+++ b/updates-site/appcast.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>AeroSpork</title>
+    <link>https://aerospork.app/appcast.xml</link>
+    <description>Updates for AeroSpork, an i3-like tiling window manager for macOS.</description>
+    <language>en</language>
+    <!-- No items yet. Sparkle reads an empty channel as "you are up to date", which is correct
+         until a release is published with a publicly reachable download URL. -->
+  </channel>
+</rss>

--- a/updates-site/index.html
+++ b/updates-site/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>AeroSpork updates</title>
+<style>
+  body{font:15px/1.55 -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+       max-width:34rem;margin:12vh auto;padding:0 1.5rem;color:#1c202c}
+  code{font:13px ui-monospace,"SF Mono",Menlo,monospace;background:#f2f2f4;padding:.15em .4em;border-radius:4px}
+  a{color:#0064e1}
+  @media (prefers-color-scheme:dark){body{background:#14161c;color:#e6e8ee}code{background:#22262f}}
+</style>
+<h1>AeroSpork updates</h1>
+<p>This host serves the Sparkle appcast for
+<a href="https://github.com/wbsmolen/aerospork">AeroSpork</a>, an i3-like tiling window manager for
+macOS. It is machine-readable infrastructure, not a download page.</p>
+<p>The feed is at <code>/appcast.xml</code>. Updates are signed with an EdDSA key whose public half
+is compiled into the app, so a build refuses any update it cannot verify.</p>
+<p>To install, see the repository.</p>


### PR DESCRIPTION
Points the Sparkle feed at `aerospork.app`, now that the domain is registered and serving.

## What is live

`aerospork.app` and `www.aerospork.app` are both `Ready` on the Static Web App with DigiCert managed
certs, auto-renewing to 2027-01-30. `http://` 301s to `https://`. DNS is an ALIAS at the apex plus a
CNAME for `www`, with the TXT validation record Azure needed; Porkbun's two parking records are gone.

## Compatibility

`SUFeedURL` is compiled into each build, so this reaches users only on the next release. Copies of
1.1.0 and earlier ask `agreeable-glacier-0a845c510.7.azurestaticapps.net`, which is the Static Web
App's own default hostname and cannot be removed while the app exists. Both hostnames serve the same
content, so those copies keep updating. Retiring the Static Web App would strand them silently, since
Sparkle reads an unreachable feed as "nothing to report" — that is recorded in `project.yml` and
`updates-site/README.md` so it does not have to be rediscovered.

## Also here

The two files the Static Web App serves had only ever been deployed by hand. They are checked in
under `updates-site/` with the deploy command.

The install docs still said `/Applications/aerospork.app`; the bundle has been `AeroSpork.app` since
the rename, confirmed against the published v1.1.0 zip. Nine occurrences fixed — the old spelling
also now reads as the domain.

## Checks

`swift test` green across both targets, `build-docs.sh` clean with 38 man pages, generated plist
verified to carry the new `SUFeedURL`.