### PR TITLE
Make the Sparkle update path actually able to install

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -313,6 +313,16 @@ cd .release
     mkdir -p "aerospork-v$build_version/bin"
     ln -sf "../AeroSpork.app/Contents/MacOS/aerospork-cli" "aerospork-v$build_version/bin/aerospork"
     zip -ry "aerospork-v$build_version.zip" "aerospork-v$build_version"
+
+    # A SECOND archive, for Sparkle only. The zip above is a distribution bundle: the .app sits
+    # under aerospork-v$VERSION/ next to bin/, manpage/ and legal/. Sparkle refuses that outright
+    # -- "No supported items ... only .app bundles are supported" -- because it expects the bundle
+    # at the archive root. Pointing the appcast at the distribution zip produces a feed that every
+    # client fails to install.
+    #
+    # ditto rather than zip: it preserves the bundle's internal symlinks, extended attributes and
+    # the stapled notarization ticket, which plain zip mangles.
+    ditto -c -k --keepParent AeroSpork.app "AeroSpork-$build_version.zip"
 cd -
 
 #################

--- a/project.yml
+++ b/project.yml
@@ -33,7 +33,14 @@ targets:
         SWIFT_VERSION: 6.0
         GENERATE_INFOPLIST_FILE: YES
         MARKETING_VERSION: ${XCODEGEN_AEROSPORK_VERSION}
-        CURRENT_PROJECT_VERSION: 1
+        # CFBundleVersion, and the field Sparkle compares to decide whether an update is newer:
+        # it becomes <sparkle:version> in the appcast. This was hardcoded to 1, so every build
+        # ever shipped claimed the same version -- 1.1.0 and 1.1.1 were both "1" -- and Sparkle
+        # could never offer an update to anyone. It has to track the release version.
+        #
+        # It must never go backwards, and it must match what the downloaded build reports, or
+        # Sparkle re-offers the same update forever.
+        CURRENT_PROJECT_VERSION: ${XCODEGEN_AEROSPORK_VERSION}
         # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-108256
         # Specifies whether the app runs as an agent app. If this key is set to YES, Launch Services runs the app as an agent app.
         # Agent apps do not appear in the Dock or in the Force Quit window


### PR DESCRIPTION
Two defects, either of which alone makes in-app updates a no-op. Both found by running
`generate_appcast` against real 1.1.1 artifacts rather than assuming the feed would work.

## `CFBundleVersion` was constant

`CURRENT_PROJECT_VERSION` was hardcoded to `1`, so every build ever shipped reported
`CFBundleVersion: 1` — the installed 1.1.0 and a fresh 1.1.1 build both do. That is the field Sparkle
compares, and it becomes `<sparkle:version>` in the appcast, so no client would ever be offered an
update. It now tracks the release version.

It must never go backwards and must match what the downloaded build reports, or Sparkle re-offers the
same update forever; that constraint is recorded next to the setting.

## The release zip is not a Sparkle archive

The distribution zip puts the bundle under `aerospork-v$VERSION/`, next to `bin/`, `manpage/` and
`legal/`. Sparkle refuses it:

```
Skipped aerospork-v1.1.1.zip Error Domain=SUSparkleErrorDomain Code=4002
"No supported items ... [note: only .app bundles are supported]"
```

An appcast pointing at that would fail on every client. `build-release.sh` now also emits
`AeroSpork-$VERSION.zip` containing just the bundle, via `ditto` so the stapled ticket and the
bundle's internal symlinks survive — plain `zip` mangles both.

## Note

The distribution zip stays as-is; it is what the releases page and the cask use. The new archive
exists only for the feed.