### PR TITLE
Fix opening the settings window

### DIFF
--- a/Sources/AppBundle/command/impl/OpenSettingsCommand.swift
+++ b/Sources/AppBundle/command/impl/OpenSettingsCommand.swift
@@ -5,15 +5,11 @@ struct OpenSettingsCommand: Command {
     let args: OpenSettingsCmdArgs
 
     func run(_ env: CmdEnv, _ io: CmdIo) -> Bool {
-        // The settings window is a `Settings` scene, so AppKit owns opening it. The selector was
-        // renamed in Sonoma; this app supports Ventura, hence the branch.
-        NSApplication.shared.activate(ignoringOtherApps: true)
-        let selector = if #available(macOS 14, *) {
-            Selector(("showSettingsWindow:"))
-        } else {
-            Selector(("showPreferencesWindow:"))
-        }
-        guard NSApp.sendAction(selector, to: nil, from: nil) else {
+        // Goes through `\.openSettings`, captured by the menu bar label. This used to send the
+        // private `showSettingsWindow:` selector, which on macOS 27 is still accepted by the
+        // responder chain but no longer opens the window -- `sendAction` returned true, so this
+        // guard passed and the command exited 0 having done nothing visible.
+        guard openSettingsWindow() else {
             return io.err("Couldn't open the settings window")
         }
         return true

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -70,8 +70,15 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
             }
         }.keyboardShortcut("E", modifiers: .command)
         Divider()
-        Button("Settings…") { openSettingsWindow() }
-            .keyboardShortcut(",", modifiers: .command)
+        // `SettingsLink` rather than a Button that sends an action: it is the supported way to open
+        // a `Settings` scene, and unlike the private selector it does not quietly do nothing.
+        if #available(macOS 14, *) {
+            SettingsLink { Text("Settings…") }
+                .keyboardShortcut(",", modifiers: .command)
+        } else {
+            Button("Settings…") { openSettingsWindow() }
+                .keyboardShortcut(",", modifiers: .command)
+        }
         // Only in a build that has a feed to check. Rendering a disabled row in a debug build
         // would be a permanent dead control, which is what the deleted settings submenu was.
         if Updater.shared.isEnabled {
@@ -84,22 +91,57 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
             }
         }.keyboardShortcut("Q", modifiers: .command)
     } label: {
-        if viewModel.isEnabled {
-            MenuBarLabel(text: viewModel.trayText, items: viewModel.trayItems)
-        } else {
-            Image(systemName: "pause.circle.fill")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-        }
+        settingsBridged(
+            Group {
+                if viewModel.isEnabled {
+                    MenuBarLabel(text: viewModel.trayText, items: viewModel.trayItems)
+                } else {
+                    Image(systemName: "pause.circle.fill")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                }
+            },
+        )
     }
 }
 
-@MainActor func openSettingsWindow() {
-    NSApplication.shared.activate(ignoringOtherApps: true)
-    // The standard action for a `Settings` scene. Selector name changed in Ventura.
-    if #available(macOS 14, *) {
-        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-    } else {
-        NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+/// `\.openSettings`, lifted out of the SwiftUI environment so code that is not a view can call it.
+/// The CLI's `open-settings` runs on the server with no environment to read from, which is why it
+/// used to send `showSettingsWindow:` instead.
+///
+/// That selector is private, and on macOS 27 it stopped opening anything while *still being claimed
+/// by the responder chain*: `sendAction` returns true, so `OpenSettingsCommand`'s error path never
+/// fired and the command reported success having done nothing. A public API that fails loudly is
+/// worth the indirection; `settingsOpener == nil` is a real state the caller has to handle.
+@MainActor var settingsOpener: (() -> Void)?
+
+/// Wraps the menu bar label, which is the one view in this scene that is always rendered, so the
+/// bridge is live before anyone opens the menu. Attaching it to the menu *content* would only
+/// capture the action after the user had already opened the menu once.
+@available(macOS 14, *)
+private struct SettingsBridge<Content: View>: View {
+    @Environment(\.openSettings) private var openSettings
+    let content: Content
+
+    var body: some View {
+        content.onAppear { settingsOpener = { openSettings() } }
     }
+}
+
+@MainActor @ViewBuilder
+func settingsBridged(_ content: some View) -> some View {
+    if #available(macOS 14, *) { SettingsBridge(content: content) } else { content }
+}
+
+/// Returns whether the window was actually asked to open, so callers can report failure instead of
+/// silently succeeding.
+@discardableResult
+@MainActor func openSettingsWindow() -> Bool {
+    NSApplication.shared.activate(ignoringOtherApps: true)
+    if let settingsOpener {
+        settingsOpener()
+        return true
+    }
+    // macOS 13 has no `\.openSettings`. The pre-Ventura selector is still the only route there.
+    return NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
 }

--- a/build-debug-app.sh
+++ b/build-debug-app.sh
@@ -21,6 +21,30 @@ mkdir -p "$APP_BUNDLE/Contents/Resources"
 echo "Copying executable..."
 cp .build/debug/aerosporkApp "$APP_BUNDLE/Contents/MacOS/AeroSporkApp"
 
+# Sparkle. The executable links it as @rpath/Sparkle.framework/Versions/B/Sparkle, so without a
+# copy inside the bundle the debug app does not start at all -- dyld kills it before main() with
+# "Library not loaded". SwiftPM leaves the framework in .build, which the .app cannot reach.
+#
+# cp -R, never cp -r: the framework is a versioned bundle built out of symlinks, and -r replaces
+# them with copies, which produces "bundle format is ambiguous".
+echo "Copying Sparkle.framework..."
+sparkle_src=".build/out/Products/Debug/Sparkle.framework"
+if ! test -d "$sparkle_src"; then
+    sparkle_src=$(find .build/artifacts -type d -name Sparkle.framework -path "*macos*" | head -1)
+fi
+if test -d "$sparkle_src"; then
+    mkdir -p "$APP_BUNDLE/Contents/Frameworks"
+    cp -R "$sparkle_src" "$APP_BUNDLE/Contents/Frameworks/"
+    # The release build gets this from LD_RUNPATH_SEARCH_PATHS in project.yml. SwiftPM does not
+    # set it, so the debug binary searches @executable_path but never ../Frameworks, and dyld
+    # fails even with the framework sitting right there. Ignore the error if it is already present.
+    install_name_tool -add_rpath "@executable_path/../Frameworks" \
+        "$APP_BUNDLE/Contents/MacOS/AeroSporkApp" 2>/dev/null || true
+else
+    echo "!!! Sparkle.framework not found; the debug app will not launch." > /dev/stderr
+    exit 1
+fi
+
 # Copy Info.plist
 echo "Copying Info.plist..."
 cp resources/Info-Debug.plist "$APP_BUNDLE/Contents/Info.plist"


### PR DESCRIPTION
The menu bar's **Settings…** and `aerospork open-settings` both did nothing. The CLI exited 0, so it
looked like it had worked.

## Why

Both routes sent the private `showSettingsWindow:` selector with `to: nil`, which walks the responder
chain starting at the key window. AeroSpork is an accessory app that normally has **no windows at all**
and is not frontmost, so nothing in the chain acts on it — but `NSApplication` still claims the action:

```
$ aerospork open-settings ; echo $?
0            # sendAction returned true, so the guard passed
$ osascript -e '... process "AeroSpork" to get count of windows'
0            # nothing opened
```

That is why `OpenSettingsCommand`'s existing error path never fired. A throwaway app with a Settings
window already open handles the same selector fine, which is what makes this look correct in isolation
— I built one to check before concluding the selector was simply broken on macOS 27. It isn't.

## Fix

Supported API on both routes: `SettingsLink` for the menu item, `\.openSettings` for the CLI.

`\.openSettings` is only readable inside a view and the CLI runs on the server with no view, so the
menu bar **label** captures it into `settingsOpener` on appear. The label, not the menu content —
content `onAppear` does not fire until the menu is first opened, which I confirmed with a probe before
choosing where to put it. `openSettingsWindow()` now returns whether it did anything, so silent
success is no longer possible.

macOS 13 keeps the old selector path; `SettingsLink` and `\.openSettings` are 14+.

## Verified

Against a real debug build, with the release build stopped so only one instance was running:

| | windows before | after |
|---|---|---|
| before fix | 0 | 0 |
| after fix | 0 | 1, titled "General" |

## Second commit: the debug .app could not launch

`build-debug-app.sh` never copied `Sparkle.framework`, so since Sparkle landed the debug app died in
dyld before `main()`. Copying it is not sufficient either — the release build gets
`@executable_path/../Frameworks` from `LD_RUNPATH_SEARCH_PATHS` in `project.yml` and SwiftPM does not
set it, so `install_name_tool` adds it. Found while trying to reproduce the bug above.

`./run-tests.sh` green.