### PR TITLE
Run the pre-quit cleanup for every way of quitting

### DIFF
--- a/Sources/AppBundle/AppDelegate.swift
+++ b/Sources/AppBundle/AppDelegate.swift
@@ -1,0 +1,40 @@
+import AppKit
+import Common
+
+/// Runs the pre-quit cleanup for the ways of stopping the app that AppKit owns rather than POSIX:
+/// an AppleEvent quit (`osascript -e 'tell application "AeroSpork" to quit'`), Force Quit's polite
+/// first attempt, and logout / restart / shut down.
+///
+/// The cleanup is `makeAllWindowsVisibleAndRestoreSize()`. Hidden workspaces are emulated by parking
+/// their windows off screen, so skipping it leaves them there: the next launch re-detects them at
+/// those coordinates and files them under whatever workspace covers that area. Windows come back on
+/// the wrong workspace, which reads as the app losing the layout.
+///
+/// Until this existed, only the menu bar's Quit item ran it. The signal handlers did not cover the
+/// gap: they were registered `if isDebug`, so a release build trapped nothing at all; one of the two
+/// was `SIGKILL`, which POSIX does not permit anyone to catch, so it never ran either; and `SIGTERM`
+/// -- what logout, restart and `killall` actually send -- was not among them.
+@MainActor
+public final class AeroSporkAppDelegate: NSObject, NSApplicationDelegate {
+    /// The menu bar's Quit reaches `NSApp.terminate` too, so this can be entered twice. Restoring an
+    /// already-restored window is harmless but slow, and the second pass would run while the first
+    /// is still moving windows.
+    private var cleanupStarted = false
+
+    public func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if cleanupStarted { return .terminateNow }
+        cleanupStarted = true
+        // `.terminateLater` rather than doing this synchronously: the cleanup is a batch of
+        // Accessibility writes across every hidden window, and blocking the main thread through it
+        // is what makes a logout appear to hang.
+        Task {
+            defer { sender.reply(toApplicationShouldTerminate: true) }
+            do {
+                try await terminationHandler.beforeTermination()
+            } catch {
+                AppLog.session.error("Cleanup before quit failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        return .terminateLater
+    }
+}

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -8,9 +8,16 @@ import Foundation
     initServerArgs()
     if isDebug {
         sendCommandToReleaseServer(args: ["enable", "off"])
-        interceptTermination(SIGINT)
-        interceptTermination(SIGKILL)
     }
+    // Not `if isDebug`. Hidden workspaces are emulated by parking windows off screen, and
+    // `beforeTermination` is what puts them back; a release build needs that at least as much as a
+    // debug one, and until now it registered no handlers at all.
+    //
+    // SIGTERM, not SIGKILL: SIGKILL cannot be caught by anyone, so registering it only implied a
+    // guarantee that never existed, while SIGTERM -- what `killall`, logout, restart and shut down
+    // send -- went untrapped. AppKit-initiated quits are handled by `AeroSporkAppDelegate`.
+    interceptTermination(SIGINT)
+    interceptTermination(SIGTERM)
     if !reloadConfig() {
         check(reloadConfig(forceConfigUrl: defaultConfigUrl))
     }

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -84,12 +84,11 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
         if Updater.shared.isEnabled {
             Button("Check for Updates…") { Updater.shared.checkForUpdates() }
         }
-        Button("Quit \(aeroSporkAppName)") {
-            runDetached("menuBarQuit") {
-                defer { terminateApp() }
-                try await terminationHandler.beforeTermination()
-            }
-        }.keyboardShortcut("Q", modifiers: .command)
+        // Just terminate: `AeroSporkAppDelegate.applicationShouldTerminate` runs the cleanup for
+        // every quit route, so doing it here too would mean two paths, one of which only this
+        // button exercised -- which is how the other routes went unnoticed for so long.
+        Button("Quit \(aeroSporkAppName)") { terminateApp() }
+            .keyboardShortcut("Q", modifiers: .command)
     } label: {
         settingsBridged(
             Group {

--- a/Sources/AppBundleTests/TerminationCoverageTest.swift
+++ b/Sources/AppBundleTests/TerminationCoverageTest.swift
@@ -1,0 +1,77 @@
+@testable import AppBundle
+import XCTest
+
+/// Quitting has to put hidden workspaces' windows back on screen, whichever way it is asked to
+/// stop. Hidden workspaces are emulated by parking windows off screen, so a quit that skips
+/// `beforeTermination` leaves them there and the next launch files them under whatever workspace
+/// covers those coordinates -- the layout appears to have been lost.
+///
+/// This was broken in every release build: the handlers were registered inside `if isDebug`, one of
+/// the two was `SIGKILL` (which POSIX does not allow anyone to catch, so it never ran), and SIGTERM
+/// was absent. Only the menu bar's Quit item cleaned up.
+///
+/// Source-scanning rather than behavioural: registering real handlers or terminating the app is not
+/// something a unit test can do, but the two ways this regressed are both visible in the text.
+final class TerminationCoverageTest: XCTestCase {
+    private var initSource: String {
+        (try? String(contentsOf: projectRoot.appending(path: "Sources/AppBundle/initAppBundle.swift"), encoding: .utf8)) ?? ""
+    }
+
+    func testSigtermIsIntercepted() {
+        XCTAssertTrue(
+            initSource.contains("interceptTermination(SIGTERM)"),
+            """
+            SIGTERM is not intercepted. It is what killall, logout, restart and shut down send, so
+            without it those quits skip beforeTermination() and windows come back on the wrong
+            workspace.
+            """,
+        )
+    }
+
+    func testSigkillIsNotPretendedToBeCatchable() {
+        XCTAssertFalse(
+            initSource.contains("interceptTermination(SIGKILL)"),
+            """
+            SIGKILL cannot be caught -- POSIX forbids it, and signal() fails silently. Registering
+            it does nothing except make the termination path look covered when it is not.
+            """,
+        )
+    }
+
+    func testTerminationHandlersAreNotDebugOnly() {
+        // The registrations must not sit inside the `if isDebug` block. That block ends at the
+        // first line that closes it, so anything after that closing brace applies to both builds.
+        let lines = initSource.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard let debugBlockStart = lines.firstIndex(where: { $0.contains("if isDebug {") }) else {
+            return XCTFail("Could not find the `if isDebug` block in initAppBundle.swift")
+        }
+        guard let debugBlockEnd = lines[debugBlockStart...].firstIndex(where: { $0.trimmingCharacters(in: .whitespaces) == "}" }) else {
+            return XCTFail("Could not find the end of the `if isDebug` block")
+        }
+        let insideDebugBlock = lines[debugBlockStart ... debugBlockEnd].joined(separator: "\n")
+        XCTAssertFalse(
+            insideDebugBlock.contains("interceptTermination("),
+            """
+            Termination handlers are registered inside `if isDebug`, so a release build traps
+            nothing. That is the configuration that shipped, and it meant every release quit except
+            the menu bar item skipped the cleanup.
+            """,
+        )
+    }
+
+    /// AppKit-initiated quits never reach a POSIX signal handler at all.
+    func testAppKitQuitsAreCovered() {
+        let delegate = (try? String(contentsOf: projectRoot.appending(path: "Sources/AppBundle/AppDelegate.swift"), encoding: .utf8)) ?? ""
+        XCTAssertTrue(
+            delegate.contains("applicationShouldTerminate"),
+            """
+            No applicationShouldTerminate. An AppleEvent quit, Force Quit, logout, restart and shut
+            down are AppKit-initiated and send no signal, so they would skip the cleanup entirely.
+            """,
+        )
+        XCTAssertTrue(
+            delegate.contains("beforeTermination"),
+            "The delegate must actually run the cleanup, not merely exist.",
+        )
+    }
+}

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -484,6 +484,22 @@ final class ConfigTest: XCTestCase {
         assertEquals(ConfigurationWriter.render(baseText: Self.lossyConfigSample, from: vm), Self.lossyConfigSample)
     }
 
+    /// The same invariant, on a file that ends with a newline.
+    ///
+    /// The sample above does not end with one, because a Swift `"""` literal has no trailing
+    /// newline, so every writer test ran against input that no editor produces. A writer that
+    /// dropped or added a final newline would have round-tripped "identically" through the whole
+    /// suite while putting a one-byte diff in the user's dotfiles on every save.
+    ///
+    /// It passes today. It is here because the gap in coverage was real, not because it caught
+    /// anything.
+    func testWriterNoOpSavePreservesATrailingNewline() {
+        let vm = ConfigurationViewModel()
+        vm.markLoaded() // nothing edited
+        let base = Self.lossyConfigSample + "\n"
+        assertEquals(ConfigurationWriter.render(baseText: base, from: vm), base)
+    }
+
     /// Editing one gap must rewrite `[gaps]` and nothing else -- the fingerprint, the fallback
     /// list, the multi-command binding and the comment all stay untouched.
     func testWriterEditingGapsLeavesEverythingElseIntact() {

--- a/Sources/aerosporkApp/aerosporkApp.swift
+++ b/Sources/aerosporkApp/aerosporkApp.swift
@@ -9,6 +9,11 @@ struct aerosporkApp: App {
     @MainActor // macOS 13
     @StateObject var viewModel = TrayMenuModel.shared
 
+    /// Gives the app a delegate so `applicationShouldTerminate` runs the pre-quit cleanup. Without
+    /// one, quitting by any route other than the menu bar item left hidden workspaces' windows
+    /// parked off screen, and the next launch filed them under the wrong workspace.
+    @NSApplicationDelegateAdaptor(AeroSporkAppDelegate.self) var appDelegate
+
     init() {
         initAppBundle()
     }


### PR DESCRIPTION
Windows came back on the wrong workspace after a restart — ones left on `A` reappeared on `3`.

## Why

Hidden workspaces are emulated by parking their windows off screen. `beforeTermination()` puts them
back. Almost nothing reached it:

```swift
if isDebug {                       // release builds trap NO signals at all
    interceptTermination(SIGINT)
    interceptTermination(SIGKILL)  // POSIX forbids catching SIGKILL — dead line
}
```

- Registered inside `if isDebug`, so a **release build trapped nothing**.
- One of the two was `SIGKILL`, which cannot be caught by anyone, so it never ran even in debug.
- `SIGTERM` — what `killall`, logout, restart and shut down send — was absent.
- AppKit-initiated quits (AppleEvent quit, Force Quit, logout) send no signal at all, and there was
  no `applicationShouldTerminate`.

So in a release build the **only** route that cleaned up was the menu bar's Quit item. Every other
one left windows parked off screen; the next launch re-detected them at those coordinates and filed
them under whatever workspace covered that area.

## Fix

- `AeroSporkAppDelegate.applicationShouldTerminate` covers the AppKit routes, using `.terminateLater`
  so a batch of Accessibility writes doesn't block a logout.
- `SIGKILL` → `SIGTERM`, and both registrations move out of the `isDebug` block.
- The menu item now just terminates. Cleanup has one path instead of a second that only that button
  exercised — which is precisely why the other routes went unnoticed.

## Tests

`TerminationCoverageTest` pins all four properties. Mutation-checked: reinstating the old
arrangement fails 3 of 4 (the 4th covers the delegate, which that mutation doesn't touch).

Also corrects a comment on the trailing-newline writer test added alongside it — that test passes and
documents a real coverage gap (`"""` literals have no trailing newline, so no writer test used input
an editor would produce), but it did not catch a bug and no longer claims to.

`./run-tests.sh` green.