### PR TITLE
Give settings text fields a real placeholder

### DIFF
--- a/Sources/AppBundle/ui/ConfigurationTabs/CallbacksTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/CallbacksTab.swift
@@ -39,13 +39,9 @@ struct CallbacksTab: View {
                 Toggle("Inherit this app's environment", isOn: viewModel.binding(\.execInheritEnvVars))
                 ForEach(viewModel.execEnvVars) { row in
                     HStack(spacing: 8) {
-                        TextField("NAME", text: envBinding(row.id, \.name))
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
+                        SettingsField("Variable name", prompt: "NAME", text: envBinding(row.id, \.name))
                             .frame(width: 150)
-                        TextField("value", text: envBinding(row.id, \.value))
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
+                        SettingsField("Variable value", prompt: "value", text: envBinding(row.id, \.value))
                         removeButton {
                             viewModel.execEnvVars.removeAll { $0.id == row.id }
                             viewModel.markAsModified()
@@ -80,9 +76,7 @@ struct CallbacksTab: View {
             }
             ForEach(viewModel[keyPath: keyPath]) { row in
                 HStack(spacing: 8) {
-                    TextField("command", text: commandBinding(keyPath, row.id))
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(.body, design: .monospaced))
+                    SettingsField("Command", prompt: "command", text: commandBinding(keyPath, row.id))
                     removeButton {
                         viewModel[keyPath: keyPath].removeAll { $0.id == row.id }
                         viewModel.markAsModified()

--- a/Sources/AppBundle/ui/ConfigurationTabs/KeyBindingsTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/KeyBindingsTab.swift
@@ -133,9 +133,7 @@ struct KeyBindingsTab: View {
             if let rowId = b.rowId {
                 KeyRecorderField(notation: key(rowId, b.key), isRecording: recorder(b.key), showsClear: false)
                     .frame(width: 150, height: 22)
-                TextField("command", text: command(rowId, b.command))
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
+                SettingsField("Command", prompt: "command", text: command(rowId, b.command))
                     .accessibilityLabel("Command for \(b.key)")
                 Button { remove(rowId) } label: { Image(systemName: "minus.circle") }
                     .buttonStyle(.borderless)
@@ -207,9 +205,7 @@ struct KeyBindingsTab: View {
             HStack(spacing: 8) {
                 KeyRecorderField(notation: $newKey, isRecording: $recording)
                     .frame(width: 170, height: 22)
-                TextField("command, e.g. focus left", text: $newCommand)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
+                SettingsField("New command", prompt: "command, e.g. focus left", text: $newCommand)
                     .onSubmit(add)
                 // "Add" on a taken shortcut is a lie: it replaces. Saying which of the two it is
                 // *before* the click is the whole point of the conflict check.

--- a/Sources/AppBundle/ui/ConfigurationTabs/WindowRulesTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/WindowRulesTab.swift
@@ -77,24 +77,16 @@ struct WindowRulesTab: View {
             Form {
                 Section {
                     LabeledContent("App ID") {
-                        TextField("com.apple.finder", text: field(i, \.appId))
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
+                        SettingsField("App ID", prompt: "com.apple.finder", text: field(i, \.appId))
                     }
                     LabeledContent("App name") {
-                        TextField("regex, optional", text: field(i, \.appNameRegex))
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
+                        SettingsField("App name", prompt: "regex, optional", text: field(i, \.appNameRegex))
                     }
                     LabeledContent("Window title") {
-                        TextField("regex, optional", text: field(i, \.windowTitleRegex))
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
+                        SettingsField("Window title", prompt: "regex, optional", text: field(i, \.windowTitleRegex))
                     }
                     LabeledContent("Workspace") {
-                        TextField("optional", text: field(i, \.workspace))
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
+                        SettingsField("Workspace", prompt: "optional", text: field(i, \.workspace))
                     }
                 } header: {
                     SectionLabel("Match when…", "line.3.horizontal.decrease.circle")
@@ -103,9 +95,7 @@ struct WindowRulesTab: View {
                 }
 
                 Section {
-                    TextField("move-node-to-workspace 3", text: field(i, \.run))
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(.body, design: .monospaced))
+                    SettingsField("Command to run", prompt: "move-node-to-workspace 3", text: field(i, \.run))
                     Toggle("Keep checking later rules", isOn: Binding(
                         get: { viewModel.windowRules[i].checkFurtherCallbacks },
                         set: {

--- a/Sources/AppBundle/ui/ConfigurationTabs/WorkspacesMonitorsTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/WorkspacesMonitorsTab.swift
@@ -96,9 +96,7 @@ struct WorkspacesMonitorsTab: View {
             } else {
                 Table(viewModel.assignments, selection: $selection) {
                     TableColumn("Workspace") { row in
-                        TextField("name", text: binding(row.id, \.workspace))
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
+                        SettingsField("Workspace name", prompt: "name", text: binding(row.id, \.workspace))
                     }
                     .width(min: 110, ideal: 140)
 

--- a/Sources/AppBundle/ui/SettingsChrome.swift
+++ b/Sources/AppBundle/ui/SettingsChrome.swift
@@ -46,6 +46,41 @@ struct NumberField: View {
     }
 }
 
+/// Text entry in a settings row. Use this rather than a bare `TextField`.
+///
+/// `TextField("com.apple.finder", text:)` reads like it takes a placeholder and does not: that
+/// argument is the field's *label*, and SwiftUI renders it. Inside a `Form` -- and worse, inside
+/// `LabeledContent`, which supplies a label of its own -- the row then drew its label, squeezed the
+/// field to near-zero width to make room for the second one, and spilled the intended placeholder
+/// out beside it, hyphenated across three lines: `com.ap-ple.find-er`. Every text field in the
+/// window had it, because the mistake reads as correct.
+///
+/// `prompt:` is the placeholder. `labelsHidden()` keeps the label for VoiceOver while stopping it
+/// competing with the row's own.
+struct SettingsField: View {
+    let label: String
+    let prompt: String
+    /// Monospaced by default: these fields hold app ids, commands, key notation and workspace
+    /// names, all of which are things the user could type into the config file. Pass `code: false`
+    /// for a field that holds prose, like a filter box.
+    var code = true
+    @Binding var text: String
+
+    init(_ label: String, prompt: String, code: Bool = true, text: Binding<String>) {
+        self.label = label
+        self.prompt = prompt
+        self.code = code
+        _text = text
+    }
+
+    var body: some View {
+        TextField(label, text: $text, prompt: Text(prompt))
+            .textFieldStyle(.roundedBorder)
+            .labelsHidden()
+            .font(code ? .system(.body, design: .monospaced) : .body)
+    }
+}
+
 /// The one hint style in this window. Markdown-aware, so `code` spans render as code without every
 /// call site building an AttributedString.
 struct SettingsHint: View {

--- a/Sources/AppBundleTests/UIChromeConsistencyTest.swift
+++ b/Sources/AppBundleTests/UIChromeConsistencyTest.swift
@@ -49,6 +49,29 @@ final class UIChromeConsistencyTest: XCTestCase {
         }
     }
 
+    /// `TextField("com.apple.finder", text:)` reads like it takes a placeholder. It does not -- that
+    /// argument is the field's label. Outside a Form macOS happens to draw it like a placeholder,
+    /// which is what made the mistake survive; inside a Form, and especially inside
+    /// `LabeledContent`, SwiftUI draws it as a second label, squeezes the field to nothing and
+    /// spills the text beside it hyphenated across three lines.
+    ///
+    /// Every text field in the window was written this way. `SettingsField` takes a real `prompt:`,
+    /// so the fix is not per-tab vigilance.
+    func testTabsDoNotUseATextFieldTitleAsAPlaceholder() throws {
+        // The filter box is `.plain` with its own magnifying glass, and the add-mode popover sizes
+        // itself; neither wants SettingsField's rounded border. Both are titles that macOS renders
+        // as placeholders in a non-Form context, which is legitimate.
+        let allowed = ["TextField(\"Filter\"", "TextField(\"mode name, e.g. resize\""]
+        try forEachCodeLine { path, line, code in
+            guard code.contains("TextField(\""), !code.contains("TextField(\"\",") else { return }
+            guard !allowed.contains(where: code.contains) else { return }
+            XCTFail(
+                "\(path):\(line) passes a placeholder as a TextField title -- that is the label. "
+                    + "Use SettingsField(_:prompt:text:) from SettingsChrome: \(code)",
+            )
+        }
+    }
+
     /// The status symbols are a set, not a palette: red/green is the most confusable pair there is,
     /// so which symbol goes with which meaning is decided once, in `StatusLabel.Kind`.
     func testStatusSymbolsAreNotHardcodedInTabs() throws {


### PR DESCRIPTION
The Window Rules tab rendered its row label, then a text field squeezed to almost nothing, then the
intended placeholder spilling out beside it and hyphenating — `com.ap-ple.find-er` across three
lines.

## Why

```swift
TextField("com.apple.finder", text: field(i, \.appId))   // that is the LABEL, not a placeholder
```

Outside a `Form`, macOS happens to draw the title where a placeholder would go — which is why the
mistake looked correct and why **every** text field in the window was written this way. Inside a
`Form`, and especially inside `LabeledContent` which already supplies a label, SwiftUI draws it as a
second label and leaves the field whatever width remains.

`NumberField` in `SettingsChrome` already did it properly (`TextField("", …)` + `.labelsHidden()`);
the text fields never picked that up.

## Fix

`SettingsField` in `SettingsChrome.swift`, per the shared-chrome invariant — one control rather than
13 patches. It takes a real `prompt:`, hides the label so it cannot compete with the row's own, and
owns the monospace decision in one place. The design system asks for monospace on "anything the user
could type into the config file": app ids, commands, key notation, workspace names — all of these.

Eleven fields across four tabs converted. Two stay plain deliberately: the bindings filter is
`.plain` with its own magnifying glass, and the add-mode popover sizes itself. Both are outside a
Form, where the title genuinely renders as a placeholder.

## Test

`UIChromeConsistencyTest.testTabsDoNotUseATextFieldTitleAsAPlaceholder`, allowing exactly those two.
Mutation-checked — reverting one field fails it with the file, line and offending source.

`./run-tests.sh` green.