### PR TITLE
Publish 1.1.3 in the appcast

### DIFF
--- a/updates-site/appcast.xml
+++ b/updates-site/appcast.xml
@@ -6,6 +6,15 @@
         <description>Updates for AeroSpork, an i3-like tiling window manager for macOS.</description>
         <language>en</language>
         <item>
+            <title>1.1.3</title>
+            <pubDate>Thu, 30 Jul 2026 11:23:45 -0500</pubDate>
+            <link>https://github.com/wbsmolen/aerospork</link>
+            <sparkle:version>1.1.3</sparkle:version>
+            <sparkle:shortVersionString>1.1.3</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.3/AeroSpork-1.1.3.zip" length="6241508" type="application/octet-stream" sparkle:edSignature="CWzb0IrprQyI9Fy1o6H1xyUEy58lfqvdEjVC8HbmOajBA+Ecf+qRkFumXsW3PyFVv1OTf/nNmVwdl1lrQiMzAQ=="/>
+        </item>
+        <item>
             <title>1.1.2</title>
             <pubDate>Thu, 30 Jul 2026 10:37:16 -0500</pubDate>
             <link>https://github.com/wbsmolen/aerospork</link>


### PR DESCRIPTION
Adds the 1.1.3 item. 1.1.2 and 1.1.1 stay, so a client that skipped either still has a path forward.

Verified against the asset GitHub actually serves: `sign_update --verify` exits 0 for `AeroSpork-1.1.3.zip` and non-zero for the distribution zip.