### PR TITLE
Fix window rules being invisible, and polish the settings window

### DIFF
--- a/Sources/AppBundle/config/ConfigurationWriter.swift
+++ b/Sources/AppBundle/config/ConfigurationWriter.swift
@@ -352,12 +352,47 @@ enum ConfigurationWriter {
         lines.append(contentsOf: block)
     }
 
+    /// A rule the `[on-window]` shorthand can express: an app id and a command, nothing else.
+    /// `parseOnWindow` builds exactly `if.app-id` + `run` from each entry, so any other matcher or
+    /// flag has to be written long form.
+    private static func isShorthandExpressible(_ rule: ConfigurationViewModel.WindowRuleRow) -> Bool {
+        !rule.appId.isEmpty
+            && rule.appNameRegex.isEmpty
+            && rule.windowTitleRegex.isEmpty
+            && rule.workspace.isEmpty
+            && !rule.checkFurtherCallbacks
+            && rule.duringStartup == nil
+    }
+
     private static func replaceWindowRules(_ lines: inout [String], _ vm: ConfigurationViewModel) {
         removeArrayOfTables(&lines, named: "on-window-detected")
+        // The shorthand table too. Removing only the long form left a v2 user's `[on-window]` rules
+        // in the file alongside the long-form copy this writes, so every one of them applied twice.
+        removeSections(&lines) { $0 == "on-window" }
         // A rule with no `run` yet is one the user is still filling in (the natural order is
         // matcher first, command second). It is skipped here because `run` is required by the
         // parser -- but the row is NOT dropped from the view model, so it stays on screen.
-        for rule in vm.windowRules where !rule.run.trimmingCharacters(in: .whitespaces).isEmpty {
+        let rules = vm.windowRules.filter { !$0.run.trimmingCharacters(in: .whitespaces).isEmpty }
+
+        // Keep a config that was written in the v2 shorthand in the v2 shorthand, but only when
+        // EVERY rule fits it and no app id repeats. Anything else is written long form.
+        //
+        // All-or-nothing on purpose. `parseConfigV2` appends `[on-window]` *after*
+        // `on-window-detected`, so in a mixed file the long-form rules always get first refusal
+        // regardless of where they sit in the text -- a list the user had ordered in the GUI would
+        // not run in that order. With no long-form rules there is nothing to take precedence, and
+        // app ids are unique, so order genuinely cannot matter.
+        let appIds = rules.map(\.appId)
+        if !rules.isEmpty, rules.allSatisfy(isShorthandExpressible), Set(appIds).count == appIds.count {
+            var block = ["", "[on-window]"]
+            for rule in rules.sorted(by: { $0.appId < $1.appId }) {
+                block.append("\(quoted(rule.appId)) = \(tomlArray(splitCommands(rule.run)))")
+            }
+            lines.append(contentsOf: block)
+            return
+        }
+
+        for rule in rules {
             var block = ["", "[[on-window-detected]]"]
             if !rule.appId.isEmpty { block.append("if.app-id = \(quoted(rule.appId))") }
             if !rule.appNameRegex.isEmpty { block.append("if.app-name-regex-substring = \(quoted(rule.appNameRegex))") }

--- a/Sources/AppBundle/ui/ConfigurationTabs/CallbacksTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/CallbacksTab.swift
@@ -36,12 +36,12 @@ struct CallbacksTab: View {
             )
 
             Section {
-                Toggle("Inherit this app's environment", isOn: viewModel.binding(\.execInheritEnvVars))
+                Toggle("Inherit AeroSpork's environment", isOn: viewModel.binding(\.execInheritEnvVars))
                 ForEach(viewModel.execEnvVars) { row in
                     HStack(spacing: 8) {
-                        SettingsField("Variable name", prompt: "NAME", text: envBinding(row.id, \.name))
+                        SettingsField("Variable name", prompt: "PATH", text: envBinding(row.id, \.name))
                             .frame(width: 150)
-                        SettingsField("Variable value", prompt: "value", text: envBinding(row.id, \.value))
+                        SettingsField("Variable value", prompt: "/opt/homebrew/bin:/usr/bin", text: envBinding(row.id, \.value))
                         removeButton {
                             viewModel.execEnvVars.removeAll { $0.id == row.id }
                             viewModel.markAsModified()
@@ -76,7 +76,7 @@ struct CallbacksTab: View {
             }
             ForEach(viewModel[keyPath: keyPath]) { row in
                 HStack(spacing: 8) {
-                    SettingsField("Command", prompt: "command", text: commandBinding(keyPath, row.id))
+                    SettingsField("Command", prompt: "exec-and-forget open -a Terminal", text: commandBinding(keyPath, row.id))
                     removeButton {
                         viewModel[keyPath: keyPath].removeAll { $0.id == row.id }
                         viewModel.markAsModified()

--- a/Sources/AppBundle/ui/ConfigurationTabs/GeneralSettingsTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/GeneralSettingsTab.swift
@@ -13,11 +13,11 @@ struct GeneralSettingsTab: View {
             Section {
                 Toggle("Start AeroSpork at login", isOn: viewModel.binding(\.startAtLogin))
                 Toggle("Automatically unhide macOS hidden apps", isOn: viewModel.binding(\.automaticallyUnhideMacosHiddenApps))
-                    .help("Undo Command-H automatically, so hidden windows keep tiling")
+                    .help("Undo ⌘H automatically, so hidden windows keep tiling")
                 Toggle("Move workspaces to assigned monitors on connect", isOn: viewModel.binding(\.autoMoveWorkspacesOnMonitorConnect))
-                    .help("Re-applies workspace-to-monitor assignments when the monitor set changes")
+                    .help("Plug in a dock and your pinned workspaces go back to the monitors you assigned them. Off, they stay wherever they landed when the monitor went away.")
             } header: {
-                SectionLabel("Startup & Behaviour", "power")
+                SectionLabel("Startup & behaviour", "power")
             }
 
             Section {

--- a/Sources/AppBundle/ui/ConfigurationTabs/KeyBindingsTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/KeyBindingsTab.swift
@@ -53,7 +53,7 @@ struct KeyBindingsTab: View {
             // One menu instead of two naked +/- buttons whose meaning ("add a *mode*, not a
             // binding") was only discoverable through a tooltip.
             Menu {
-                Button("New Mode…") { addingMode = true }
+                Button("New mode…") { addingMode = true }
                 Button("Delete “\(selectedMode)”", role: .destructive) { removeMode() }
                     .disabled(!viewModel.canRemoveMode(selectedMode))
             } label: {
@@ -133,7 +133,7 @@ struct KeyBindingsTab: View {
             if let rowId = b.rowId {
                 KeyRecorderField(notation: key(rowId, b.key), isRecording: recorder(b.key), showsClear: false)
                     .frame(width: 150, height: 22)
-                SettingsField("Command", prompt: "command", text: command(rowId, b.command))
+                SettingsField("Command", prompt: "focus left", text: command(rowId, b.command))
                     .accessibilityLabel("Command for \(b.key)")
                 Button { remove(rowId) } label: { Image(systemName: "minus.circle") }
                     .buttonStyle(.borderless)
@@ -147,6 +147,10 @@ struct KeyBindingsTab: View {
                     .font(.system(.body, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                    .truncationMode(.middle)
+                    // Read-only rows have no field to scroll, so a chained command truncated with
+                    // no way to see the rest short of clicking Override, which edits the config.
+                    .help(b.command)
                 Spacer(minLength: 8)
                 // Generated bindings appear nowhere in the config file, so without this the tab
                 // shows dozens of rows the user cannot find when they go looking.

--- a/Sources/AppBundle/ui/ConfigurationTabs/RawTomlTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/RawTomlTab.swift
@@ -54,7 +54,7 @@ struct RawTomlTab: View {
                     }
                 }
                 .buttonStyle(.borderless)
-                .help("Re-read the config file. Normally automatic.")
+                .help("Only needed for a config file created outside the app — every other edit is picked up on save.")
             }
         }
         .padding(.horizontal, 14)

--- a/Sources/AppBundle/ui/ConfigurationTabs/WindowRulesTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/WindowRulesTab.swift
@@ -46,7 +46,7 @@ struct WindowRulesTab: View {
                 icon: "macwindow",
                 title: "No window rules",
                 message: "Rules run once, when a window first appears — the usual use is sending an app straight to its workspace.",
-                actionTitle: "Add Rule",
+                actionTitle: "Add rule",
                 action: { addRule() },
             )
         } else {
@@ -80,13 +80,13 @@ struct WindowRulesTab: View {
                         SettingsField("App ID", prompt: "com.apple.finder", text: field(i, \.appId))
                     }
                     LabeledContent("App name") {
-                        SettingsField("App name", prompt: "regex, optional", text: field(i, \.appNameRegex))
+                        SettingsField("App name", prompt: "^Finder$", text: field(i, \.appNameRegex))
                     }
                     LabeledContent("Window title") {
-                        SettingsField("Window title", prompt: "regex, optional", text: field(i, \.windowTitleRegex))
+                        SettingsField("Window title", prompt: "^Preferences$", text: field(i, \.windowTitleRegex))
                     }
                     LabeledContent("Workspace") {
-                        SettingsField("Workspace", prompt: "optional", text: field(i, \.workspace))
+                        SettingsField("Workspace", prompt: "3", text: field(i, \.workspace))
                     }
                 } header: {
                     SectionLabel("Match when…", "line.3.horizontal.decrease.circle")
@@ -95,7 +95,9 @@ struct WindowRulesTab: View {
                 }
 
                 Section {
-                    SettingsField("Command to run", prompt: "move-node-to-workspace 3", text: field(i, \.run))
+                    LabeledContent("Command") {
+                        SettingsField("Command", prompt: "move-node-to-workspace 3", text: field(i, \.run))
+                    }
                     Toggle("Keep checking later rules", isOn: Binding(
                         get: { viewModel.windowRules[i].checkFurtherCallbacks },
                         set: {

--- a/Sources/AppBundle/ui/ConfigurationTabs/WorkspacesMonitorsTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/WorkspacesMonitorsTab.swift
@@ -20,7 +20,7 @@ struct WorkspacesMonitorsTab: View {
                     viewModel.scheduleAutoSave()
                     selection = nil
                 },
-                hint: "Hardware fingerprints already in your config are preserved — they just show up here under the monitor's name. A DisplayLink panel reports no vendor or serial, so its UUID is the only thing that pins a workspace to that exact screen.",
+                hint: "Hardware fingerprints already in your config are preserved — they just show up here under the monitor's name. A DisplayLink monitor reports no vendor or serial, so its UUID is the only thing that pins a workspace to that exact monitor.",
             )
         }
     }
@@ -37,7 +37,7 @@ struct WorkspacesMonitorsTab: View {
             // Same empty-state treatment as every other list in this window, rather than a section
             // header floating above nothing.
             if viewModel.liveMonitors.isEmpty {
-                SettingsHint("No displays reported yet.")
+                SettingsHint("No monitors reported yet.")
                     .padding(.horizontal, 16)
                     .padding(.bottom, 14)
             }
@@ -62,7 +62,7 @@ struct WorkspacesMonitorsTab: View {
                                 Text(uuid.prefix(8) + "…")
                                     .font(.system(.caption, design: .monospaced))
                                     .foregroundStyle(.tertiary)
-                                CopyButton(value: uuid, help: "Copy display UUID\n\(uuid)")
+                                CopyButton(value: uuid, help: "Copy monitor UUID\n\(uuid)")
                             }
                         }
                         .padding(.horizontal, 12)
@@ -90,24 +90,24 @@ struct WorkspacesMonitorsTab: View {
                     icon: "arrow.triangle.branch",
                     title: "No assignments",
                     message: "Workspaces land wherever they were last used. Add an assignment to pin one to a specific monitor.",
-                    actionTitle: "Add Assignment",
+                    actionTitle: "Add assignment",
                     action: { viewModel.addAssignment() },
                 )
             } else {
                 Table(viewModel.assignments, selection: $selection) {
                     TableColumn("Workspace") { row in
-                        SettingsField("Workspace name", prompt: "name", text: binding(row.id, \.workspace))
+                        SettingsField("Workspace name", prompt: "web", text: binding(row.id, \.workspace))
                     }
                     .width(min: 110, ideal: 140)
 
                     TableColumn("Monitor") { row in
                         Picker("", selection: binding(row.id, \.monitor)) {
-                            Text("Primary").tag("main")
-                            Text("Non-primary").tag("secondary")
+                            Text("Main").tag("main")
+                            Text("Non-main").tag("secondary")
                             Divider()
                             ForEach(viewModel.liveMonitors) { m in
                                 Text(m.name).tag(m.name)
-                                if let uuid = m.uuid { Text("\(m.name) — exact display").tag(uuid) }
+                                if let uuid = m.uuid { Text("\(m.name) — this exact monitor").tag(uuid) }
                             }
                             // Keep whatever is already in the config selectable, even if it's a
                             // regex, a sequence number, or a monitor that isn't connected now.
@@ -121,6 +121,13 @@ struct WorkspacesMonitorsTab: View {
                     }
                 }
                 .tableStyle(.inset)
+                // Both columns are filled edge to edge by focusable controls, which swallow the
+                // click that would select the row -- so `selection` stayed nil and ListActionBar's
+                // Remove was permanently disabled. Window Rules has had this since it has Text-only
+                // cells; this table needs it to have any delete affordance at all.
+                .onDeleteCommand {
+                    if let id = selection { viewModel.removeAssignment(id: id); selection = nil }
+                }
             }
         }
         .frame(maxHeight: .infinity)

--- a/Sources/AppBundle/ui/ConfigurationViewModel.swift
+++ b/Sources/AppBundle/ui/ConfigurationViewModel.swift
@@ -517,9 +517,38 @@ final class ConfigurationViewModel: ObservableObject {
         return []
     }
 
+    /// Reads BOTH spellings.
+    ///
+    /// `[on-window]` is the v2 shorthand, and the one the shipped default config documents. It
+    /// desugars to the same `onWindowDetected` list in `parseConfigV2`, so those rules are live --
+    /// but this used to read only the long form, so a v2 config showed "No window rules" while its
+    /// rules were running. Adding a rule in that state wrote a long-form copy and left the shorthand
+    /// table behind, so every original rule then applied twice.
+    ///
+    /// Long form first, then shorthand: `parseConfigV2` appends `[on-window]` after
+    /// `on-window-detected`, so this is the order the rules are actually tried in, and the list is
+    /// read top to bottom.
     private func loadWindowRules(_ table: TOMLTable?) -> [WindowRuleRow] {
-        guard let array = table?["on-window-detected"]?.array else { return [] }
-        return array.compactMap { entry -> WindowRuleRow? in
+        var rows = (table?["on-window-detected"]?.array).map(loadLongFormWindowRules) ?? []
+        if let shorthand = table?["on-window"]?.table {
+            // Sorted to match `parseOnWindow`, which walks `table.keys.sorted()`.
+            rows += shorthand.keys.sorted().map { appId in
+                WindowRuleRow(
+                    appId: appId,
+                    appNameRegex: "",
+                    windowTitleRegex: "",
+                    workspace: "",
+                    run: commandString(shorthand[appId] ?? ""),
+                    checkFurtherCallbacks: false,
+                    duringStartup: nil,
+                )
+            }
+        }
+        return rows
+    }
+
+    private func loadLongFormWindowRules(_ array: TOMLArray) -> [WindowRuleRow] {
+        array.compactMap { entry -> WindowRuleRow? in
             guard let t = entry.table else { return nil }
             let cond = t["if"]?.table
             return WindowRuleRow(

--- a/Sources/AppBundle/ui/ConfigurationWindow.swift
+++ b/Sources/AppBundle/ui/ConfigurationWindow.swift
@@ -77,7 +77,7 @@ public struct ConfigurationWindow: View {
                         .padding(.horizontal, 14)
                         .padding(.vertical, 9)
                 }
-                .background(Color.red.opacity(0.1))
+                .background(Banner.Kind.error.tint.opacity(0.13))
             }
         }
         .task { await viewModel.loadConfiguration() }

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -26,9 +26,9 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
         // they never wrote, and every one of their bindings is gone -- they have to be told here,
         // not only in a startup dialog they already dismissed.
         if isRunningFallbackDefaults {
-            Text("⚠ Config not loaded — running defaults")
+            Label("Config not loaded — running defaults", systemImage: Banner.Kind.error.icon)
             Button("Show config error…") {
-                showMessageInGui(filenameIfConsoleApp: nil, title: "AeroSpork Config Error", message: configLoadFailure ?? "")
+                showMessageInGui(filenameIfConsoleApp: nil, title: "AeroSpork config error", message: configLoadFailure ?? "")
             }
             Divider()
         }
@@ -61,14 +61,17 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
             }
             Divider()
         }
-        Button(viewModel.isEnabled ? "Pause Tiling" : "Resume Tiling") {
+        Button(viewModel.isEnabled ? "Pause tiling" : "Resume tiling") {
             runDetached("menuBarToggleTiling") {
                 try await runSession(.menuBarButton, .forceRun) { () throws in
                     _ = try await EnableCommand(args: EnableCmdArgs(rawArgs: [], targetState: .toggle))
                         .run(.defaultEnv, .emptyStdin)
                 }
             }
-        }.keyboardShortcut("E", modifiers: .command)
+        }
+        // Lowercase. An uppercase KeyEquivalent implies Shift to AppKit, so "E"/"Q" rendered as
+        // Shift-Cmd-E / Shift-Cmd-Q and plain Cmd-Q did nothing while the menu was open.
+        .keyboardShortcut("e", modifiers: .command)
         Divider()
         // `SettingsLink` rather than a Button that sends an action: it is the supported way to open
         // a `Settings` scene, and unlike the private selector it does not quietly do nothing.
@@ -82,13 +85,13 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
         // Only in a build that has a feed to check. Rendering a disabled row in a debug build
         // would be a permanent dead control, which is what the deleted settings submenu was.
         if Updater.shared.isEnabled {
-            Button("Check for Updates…") { Updater.shared.checkForUpdates() }
+            Button("Check for updates…") { Updater.shared.checkForUpdates() }
         }
         // Just terminate: `AeroSporkAppDelegate.applicationShouldTerminate` runs the cleanup for
         // every quit route, so doing it here too would mean two paths, one of which only this
         // button exercised -- which is how the other routes went unnoticed for so long.
         Button("Quit \(aeroSporkAppName)") { terminateApp() }
-            .keyboardShortcut("Q", modifiers: .command)
+            .keyboardShortcut("q", modifiers: .command)
     } label: {
         settingsBridged(
             Group {

--- a/Sources/AppBundle/ui/SettingsChrome.swift
+++ b/Sources/AppBundle/ui/SettingsChrome.swift
@@ -78,6 +78,10 @@ struct SettingsField: View {
             .textFieldStyle(.roundedBorder)
             .labelsHidden()
             .font(code ? .system(.body, design: .monospaced) : .body)
+            // As the trailing half of a `LabeledContent`, a field inherits that row's trailing
+            // alignment and puts the caret against the right edge -- so an app id typed left to
+            // right appears to grow backwards out of the corner.
+            .multilineTextAlignment(.leading)
     }
 }
 
@@ -443,6 +447,6 @@ struct CopyButton: View {
         }
         .buttonStyle(.borderless)
         .help(help)
-        .accessibilityLabel(copied ? "Copied" : "Copy to clipboard")
+        .accessibilityLabel(copied ? "Copied" : help)
     }
 }

--- a/Sources/AppBundleTests/UIChromeConsistencyTest.swift
+++ b/Sources/AppBundleTests/UIChromeConsistencyTest.swift
@@ -49,6 +49,22 @@ final class UIChromeConsistencyTest: XCTestCase {
         }
     }
 
+    /// The symbol test below greps SF Symbol *names*, so a literal `⚠` in a string walked straight
+    /// past it -- and did, in the menu bar's config-failure row, the one surface that is always on
+    /// screen. CoreText renders those glyphs emoji-style in a menu, next to SF Symbols everywhere
+    /// else.
+    func testTabsDoNotUseGlyphsAsStatusIcons() throws {
+        let glyphs = ["⚠", "✅", "❌", "⛔", "🔴", "🟢", "‼️"]
+        try forEachCodeLine { path, line, code in
+            for glyph in glyphs {
+                XCTAssertFalse(
+                    code.contains(glyph),
+                    "\(path):\(line) uses \(glyph) as a status icon -- use StatusLabel/Banner: \(code)",
+                )
+            }
+        }
+    }
+
     /// `TextField("com.apple.finder", text:)` reads like it takes a placeholder. It does not -- that
     /// argument is the field's label. Outside a Form macOS happens to draw it like a placeholder,
     /// which is what made the mistake survive; inside a Form, and especially inside

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -574,6 +574,84 @@ final class ConfigTest: XCTestCase {
         XCTAssertTrue(out.contains("FOO = 'bar'"), out)
     }
 
+    /// `[on-window]` is the v2 shorthand and the form the shipped default config documents. The GUI
+    /// used to read only `on-window-detected`, so a v2 config showed an empty Window Rules tab while
+    /// its rules were live.
+    func testGuiSeesShorthandWindowRules() {
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: """
+            [on-window]
+            "com.apple.finder" = "move-node-to-workspace 3"
+            "com.apple.mail" = "layout floating"
+            """)
+        assertEquals(vm.windowRules.count, 2)
+        assertEquals(vm.windowRules.first?.appId, "com.apple.finder")
+        assertEquals(vm.windowRules.first?.run, "move-node-to-workspace 3")
+    }
+
+    /// Long form is tried before the shorthand (`parseConfigV2` appends `[on-window]` after it), so
+    /// the list has to be read in that order or the GUI shows rules in an order they do not run in.
+    func testGuiListsLongFormWindowRulesBeforeShorthand() {
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: """
+            [[on-window-detected]]
+            if.app-id = 'com.apple.mail'
+            run = ['layout floating']
+
+            [on-window]
+            "com.apple.finder" = "move-node-to-workspace 3"
+            """)
+        assertEquals(vm.windowRules.map(\.appId), ["com.apple.mail", "com.apple.finder"])
+    }
+
+    /// Editing a rule used to write a long-form copy while leaving the shorthand table in place, so
+    /// every original rule then matched twice.
+    func testEditingAShorthandRuleDoesNotLeaveADuplicate() {
+        let base = """
+            [on-window]
+            "com.apple.finder" = "move-node-to-workspace 3"
+            """
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: base)
+        vm.markLoaded()
+        vm.windowRules.append(.init(appId: "com.apple.mail", run: "layout floating"))
+
+        let out = ConfigurationWriter.render(baseText: base, from: vm)
+        let (config, errors) = parseConfigForTest(out)
+        assertEquals(errors, [])
+        // Two rules, not three: the original must not survive in both spellings.
+        assertEquals(config.onWindowDetected.count, 2)
+    }
+
+    /// A config written in the shorthand stays in the shorthand when every rule still fits it.
+    func testShorthandSurvivesAnEditThatStillFitsIt() {
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: "[on-window]\n\"com.apple.finder\" = \"move-node-to-workspace 3\"")
+        vm.markLoaded()
+        vm.windowRules.append(.init(appId: "com.apple.mail", run: "layout floating"))
+
+        let out = ConfigurationWriter.render(baseText: "", from: vm)
+        XCTAssertTrue(out.contains("[on-window]"), "shorthand was converted to long form:\n\(out)")
+        XCTAssertFalse(out.contains("[[on-window-detected]]"), out)
+    }
+
+    /// A matcher the shorthand cannot express forces the whole set to long form, because in a mixed
+    /// file the long-form rules take precedence regardless of text order.
+    func testARegexMatcherForcesLongFormForEveryRule() {
+        let vm = ConfigurationViewModel()
+        vm.markLoaded()
+        vm.windowRules = [
+            .init(appId: "com.apple.finder", run: "move-node-to-workspace 3"),
+            .init(appId: "", appNameRegex: "Term", run: "layout floating"),
+        ]
+
+        let out = ConfigurationWriter.render(baseText: "", from: vm)
+        XCTAssertFalse(out.contains("[on-window]"), "mixed rules must not be split across spellings:\n\(out)")
+        let (config, errors) = parseConfigForTest(out)
+        assertEquals(errors, [])
+        assertEquals(config.onWindowDetected.count, 2)
+    }
+
     /// An *applied* Raw TOML tab is authoritative -- it is exactly what lands on disk.
     /// See `ConfigurationWriterSafetyTest` for the counterpart: an unapplied buffer must NOT win.
     func testWriterRawTomlWins() {


### PR DESCRIPTION
## The Window Rules tab could not see v2 rules

A config written in the `[on-window]` shorthand — the form the shipped default config documents —
showed **"No window rules"**. `parseConfigV2` desugars that key, so the rules were live; the GUI read
only `on-window-detected`.

Worse, adding a rule in that state wrote a long-form copy and left the shorthand table in the file,
so every original rule then matched **twice**.

Reproduced against a real config in a debug build before and after:

| | Window Rules tab |
|---|---|
| before | "No window rules" |
| after | `com.apple.finder` → `move-node-to-workspace 3` |

Load reads both spellings, long form first because `parseConfigV2` appends `[on-window]` after it and
that is the order rules are tried. A save clears both. A config written in the shorthand stays in the
shorthand while every rule still fits it; anything the shorthand cannot express sends the whole set
to long form, because in a mixed file the long-form rules take precedence regardless of text order.

## Found by auditing the rest of the window

- **⌘Q and ⌘E did nothing.** An uppercase `KeyEquivalent` implies Shift to AppKit, so the menu bar's
  shortcuts were really ⇧⌘Q / ⇧⌘E. `RawTomlTab` already used lowercase.
- **A workspace-to-monitor assignment could not be deleted.** Every cell in that `Table` is a
  focusable control, which swallows the click that would select the row, so `selection` stayed `nil`
  and Remove was permanently disabled. Added `.onDeleteCommand`, as the rules table has.
- **The rule's command field had no label.** `SettingsField` hides its label assuming a
  `LabeledContent` supplies one; this call site had none.
- **Fields were right-aligned** inside their row, so text appeared to grow backwards out of the corner.
- **`CopyButton` discarded its `help:` for VoiceOver** — three buttons with different tooltips all
  announced "Copy to clipboard".
- **A generated binding's command truncated** with no tooltip, so reading a long one meant clicking
  Override, which edits the config.
- **A literal `⚠` and a second, slightly different red**, both already owned by the shared chrome.
- Sentence case; four nouns for "monitor"; "Primary" where `docs/guide.adoc` and macOS both say
  "main"; placeholders that were the word "optional" instead of an example; two help strings that
  restated their own control.

## Not changed, after checking

An audit flagged the monitor picker as emitting duplicate tags for two identical displays. It does
not: `name` is `NSScreen.localizedName`, and macOS itself disambiguates them — the reporter's own
`list-monitors` shows `DELL U3223QE (1)` and `(2)`.

## Tests

`testGuiSeesShorthandWindowRules`, `testGuiListsLongFormWindowRulesBeforeShorthand`,
`testEditingAShorthandRuleDoesNotLeaveADuplicate`, `testShorthandSurvivesAnEditThatStillFitsIt`,
`testARegexMatcherForcesLongFormForEveryRule`, and `testTabsDoNotUseGlyphsAsStatusIcons`.
Mutation-checked: 3 of 4 round-trip tests and the glyph test fail on the old code.

`./run-tests.sh` green.