### PR TITLE
Put windows back on their own monitor at quit, not the main one

### DIFF
--- a/Sources/AppBundle/util/appBundleUtil.swift
+++ b/Sources/AppBundle/util/appBundleUtil.swift
@@ -38,6 +38,24 @@ private struct AppServerTerminationHandler: TerminationHandler {
     }
 }
 
+/// Top-left corner for a window centred on `monitorVisibleRect`, in the GLOBAL coordinate space.
+///
+/// The monitor's own origin is the whole point. `visibleRect` is global -- `Rect.monitorFrameNormalized`
+/// keeps `minX` as `topLeftX` -- and `kAXPositionAttribute` is global too. Centring with only the
+/// monitor's width and height, as this did, lands every window near the origin of that space, which
+/// is the main monitor, whatever monitor the window was actually on.
+///
+/// On one display the two are identical, which is why it survived: the bug is invisible until there
+/// is a second monitor with a non-zero origin. On a multi-monitor setup it collapsed every display
+/// onto one at quit, and since the next launch binds a window by where it physically sits, everything
+/// came back on the main monitor's startup workspace.
+func centredOnMonitor(_ monitorVisibleRect: Rect, _ windowSize: CGSize) -> CGPoint {
+    monitorVisibleRect.topLeftCorner + CGPoint(
+        x: (monitorVisibleRect.width - windowSize.width) / 2,
+        y: (monitorVisibleRect.height - windowSize.height) / 2,
+    )
+}
+
 @MainActor
 private func makeAllWindowsVisibleAndRestoreSize() async throws {
     // Make all windows fullscreen before Quit
@@ -47,11 +65,7 @@ private func makeAllWindowsVisibleAndRestoreSize() async throws {
         let monitor = try await window.getCenter()?.monitorApproximation ?? mainMonitor
         let monitorVisibleRect = monitor.visibleRect
         let windowSize = window.lastFloatingSize ?? CGSize(width: monitorVisibleRect.width, height: monitorVisibleRect.height)
-        let point = CGPoint(
-            x: (monitorVisibleRect.width - windowSize.width) / 2,
-            y: (monitorVisibleRect.height - windowSize.height) / 2,
-        )
-        try await window.setAxFrameBlocking(point, windowSize)
+        try await window.setAxFrameBlocking(centredOnMonitor(monitorVisibleRect, windowSize), windowSize)
     }
 }
 

--- a/Sources/AppBundleTests/QuitCleanupGeometryTest.swift
+++ b/Sources/AppBundleTests/QuitCleanupGeometryTest.swift
@@ -1,0 +1,63 @@
+@testable import AppBundle
+import XCTest
+
+/// Where the quit cleanup puts a window back.
+///
+/// `makeAllWindowsVisibleAndRestoreSize` centres every window on its own monitor before quitting, so
+/// nothing is left parked off screen where a hidden workspace put it. It resolved the right monitor
+/// and then used only that monitor's width and height, never its origin -- and both `visibleRect`
+/// and `kAXPositionAttribute` are in the GLOBAL coordinate space. So every window landed near the
+/// origin of that space, which is the main monitor.
+///
+/// On a single display the two are the same point, which is why nobody saw it. With a second monitor
+/// it collapsed every display onto one at quit, and because the next launch binds a window by where
+/// it physically sits, everything came back on the main monitor's startup workspace. A window left
+/// on workspace `A` reappeared on `1` or `3`.
+final class QuitCleanupGeometryTest: XCTestCase {
+    /// The regression. A monitor to the right of the main one has a non-zero origin, and a window
+    /// centred on it must stay within it.
+    func testAWindowIsCentredOnItsOwnMonitorNotTheMainOne() {
+        let secondMonitor = Rect(topLeftX: 1920, topLeftY: 0, width: 2560, height: 1440)
+        let size = CGSize(width: 800, height: 600)
+
+        let point = centredOnMonitor(secondMonitor, size)
+
+        XCTAssertEqual(point.x, 1920 + (2560 - 800) / 2)
+        XCTAssertEqual(point.y, (1440 - 600) / 2)
+        XCTAssertTrue(
+            point.x >= secondMonitor.topLeftX,
+            "window placed at x=\(point.x), left of its own monitor at x=\(secondMonitor.topLeftX) -- "
+                + "it will be bound to the wrong monitor on the next launch",
+        )
+    }
+
+    /// A monitor above and to the left of the main one: both offsets negative, so an implementation
+    /// that merely adds an absolute value would pass the test above and fail this.
+    func testNegativeMonitorOriginsAreHonoured() {
+        let monitor = Rect(topLeftX: -1920, topLeftY: -1080, width: 1920, height: 1080)
+        let size = CGSize(width: 400, height: 300)
+
+        let point = centredOnMonitor(monitor, size)
+
+        XCTAssertEqual(point.x, -1920 + (1920 - 400) / 2)
+        XCTAssertEqual(point.y, -1080 + (1080 - 300) / 2)
+    }
+
+    /// The main monitor sits at the origin, so this is the case the old code got right -- and the
+    /// reason it survived. Pinned so a "fix" cannot regress it.
+    func testTheMainMonitorIsUnaffected() {
+        let main = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
+        let size = CGSize(width: 1000, height: 700)
+
+        assertEquals(centredOnMonitor(main, size), CGPoint(x: (1920 - 1000) / 2, y: (1080 - 700) / 2))
+    }
+
+    /// A window larger than the monitor centres to a negative offset rather than being clamped;
+    /// that is existing behaviour and the origin fix must not silently change it.
+    func testAnOversizedWindowStillCentres() {
+        let monitor = Rect(topLeftX: 1920, topLeftY: 0, width: 1000, height: 800)
+        let point = centredOnMonitor(monitor, CGSize(width: 1400, height: 900))
+
+        assertEquals(point, CGPoint(x: 1920 + (1000 - 1400) / 2, y: (800 - 900) / 2))
+    }
+}


### PR DESCRIPTION
The pre-quit cleanup centres every window on its monitor so none is left parked off screen where a
hidden workspace put it. It resolved the right monitor and then used only its width and height:

```swift
let monitorVisibleRect = monitor.visibleRect          // GLOBAL coordinates
let point = CGPoint(
    x: (monitorVisibleRect.width - windowSize.width) / 2,
    y: (monitorVisibleRect.height - windowSize.height) / 2,
)                                                      // ...origin dropped
try await window.setAxFrameBlocking(point, windowSize) // kAXPositionAttribute is GLOBAL too
```

`Rect.monitorFrameNormalized` keeps `minX` as `topLeftX`, so `visibleRect` is absolute; so is
`kAXPositionAttribute`. Every window therefore landed near the origin of that space — the main
monitor — regardless of where it had been.

On a single display the two points coincide, which is why it survived. On a multi-monitor setup it
collapses every display onto one at quit, and because the next launch binds a window by where it
physically sits, everything returns on the main monitor's startup workspace.

## Why this matters for #11

#11 made the cleanup run for every quit route. Before it, the cleanup mostly *didn't* run, so windows
stayed on their own monitors and kept that monitor's identity — crude, but survivable. #11 turned a
rare bug into a reliable one. `TerminationCoverageTest` pins only that the cleanup **runs**, never
where it puts anything, so nothing caught it.

## Tests

`centredOnMonitor` is extracted so the arithmetic is testable without AX or a real screen:
a monitor with a positive origin, one with negative origins, the main monitor at `(0,0)`, and an
oversized window.

Mutation-checked — with the origin dropped again, 3 of 4 fail and `testTheMainMonitorIsUnaffected`
still passes, which is precisely the reason this went unnoticed.

## Note

Upstream AeroSpace has the byte-identical expression, so this is inherited rather than
fork-introduced, and appears unreported there.

`./run-tests.sh` green.