### PR TITLE
Remember which workspace each window was on across a restart

### DIFF
--- a/Sources/AppBundle/WorkspaceMemory.swift
+++ b/Sources/AppBundle/WorkspaceMemory.swift
@@ -1,0 +1,112 @@
+import Common
+import Foundation
+
+/// Remembers which workspace each window was on, so an AeroSpork restart does not scatter them.
+///
+/// ## Why this is needed at all
+///
+/// Workspaces are emulated, not native Spaces: a hidden workspace's windows are parked off screen.
+/// Nothing outside this process knows that a window "belongs to" workspace `A`. At launch a window
+/// is bound by where it physically sits (`MacWindow.getOrRegister`), and at a cold start no
+/// workspace is active yet, so `getStubWorkspace` invents one per monitor from the first keybound
+/// name in sort order. `A` sorts after every digit, so a window left on `A` could never come back to
+/// it -- it reappeared on `1` or `3`. That is structural, not chance.
+///
+/// ## Why `CGWindowID` alone, and nothing cleverer
+///
+/// The id comes from the WindowServer, and Apple documents it as "a unique value **within the user
+/// session**". So it is *exactly* stable across a restart of AeroSpork -- the case this exists for,
+/// since our process lifetime means nothing to the WindowServer -- and worthless once the owning app
+/// restarts or the machine reboots.
+///
+/// A composite key (bundle id + title + index + frame) would appear to cover the app-restart case
+/// and cannot. `AXIdentifier` names a window *class*, not an instance: every Terminal window reports
+/// `TerminalWindowRestoration`, every Finder window `FinderWindow` -- the `axDumps/` fixtures show it.
+/// Titles change when a tab does, the index into `kAXWindowsAttribute` is z-order, and the frame is
+/// overwritten by our own quit cleanup. Three identical terminal windows are genuinely
+/// indistinguishable, so a composite key would shuffle them into an arbitrary permutation, silently
+/// and untestably. An exact id match cannot be wrong; it can only be absent.
+///
+/// So every failure here degrades to "behaves like it did before", never to "puts the window
+/// somewhere wrong". Where the id is gone, `on-window-detected` with
+/// `if.during-aerospork-startup` is the right tool, because there the user states intent instead of
+/// us guessing.
+///
+/// ## Why the boot time is in the file
+///
+/// Ids are unique *within a session*, which means they are recycled across boots. Without the guard
+/// a stale file could match a live window that happens to have inherited an old id and move it
+/// somewhere the user never put it -- the one way this design could produce a wrong answer rather
+/// than no answer. `kern.boottime` is exact and costs one `sysctl`.
+@MainActor
+enum WorkspaceMemory {
+    private struct Entry: Codable {
+        let workspace: String
+        /// Checked against the live window's app. A recycled id landing on a different application
+        /// is the residual risk the boot guard does not already remove; this makes it a no-op.
+        let bundleId: String?
+    }
+
+    private struct State: Codable {
+        let bootTime: Double
+        let windows: [String: Entry]
+    }
+
+    /// Alongside the CLI socket, and deliberately nowhere near the config: this is a disposable
+    /// cache, and `ConfigurationWriter`'s do-no-harm invariant must not be dragged into it.
+    private static var fileUrl: URL {
+        URL(filePath: "/tmp/\(aeroSporkAppId)-\(unixUserName).state.json")
+    }
+
+    /// Seconds since the epoch at which the machine last booted. Not `ProcessInfo.systemUptime`,
+    /// which is a duration and behaves differently across sleep.
+    private static var bootTime: Double {
+        var tv = timeval()
+        var size = MemoryLayout<timeval>.stride
+        guard sysctlbyname("kern.boottime", &tv, &size, nil, 0) == 0 else { return 0 }
+        return Double(tv.tv_sec)
+    }
+
+    /// Loaded once, at startup, before any window is registered. `nil` means "no usable memory",
+    /// which is the same as never having run.
+    private static var restored: [String: Entry]?
+
+    /// Reads the file if it belongs to this boot. Call once, early.
+    static func load() {
+        restored = nil
+        guard let data = try? Data(contentsOf: fileUrl),
+              let state = try? JSONDecoder().decode(State.self, from: data)
+        else { return }
+        // A file from a previous boot describes ids that no longer mean anything.
+        guard state.bootTime == bootTime else {
+            debugLog("WorkspaceMemory: discarding state from a previous boot")
+            try? FileManager.default.removeItem(at: fileUrl)
+            return
+        }
+        restored = state.windows
+        debugLog("WorkspaceMemory: restored \(state.windows.count) entries")
+    }
+
+    /// The workspace this window was on last run, if we can be certain it is the same window.
+    static func workspace(forWindowId id: UInt32, bundleId: String?) -> String? {
+        guard let entry = restored?[String(id)] else { return nil }
+        // A nil bundle id on either side is not a match: unknown is not the same as equal.
+        guard let remembered = entry.bundleId, let bundleId, remembered == bundleId else { return nil }
+        return entry.workspace
+    }
+
+    /// Snapshots the current tree. Cheap enough for the refresh debounce: a dictionary walk and a
+    /// small JSON write, on the order of the window count.
+    static func save() {
+        var windows: [String: Entry] = [:]
+        for window in MacWindow.allWindows {
+            guard let workspace = window.nodeWorkspace else { continue }
+            windows[String(window.windowId)] = Entry(workspace: workspace.name, bundleId: window.macApp.bundleId)
+        }
+        let state = State(bootTime: bootTime, windows: windows)
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        // Written on every debounced refresh rather than only at quit, because a crash never
+        // reaches the quit path -- and a crash is when this is worth the most.
+        try? data.write(to: fileUrl, options: .atomic)
+    }
+}

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -22,6 +22,10 @@ import Foundation
         check(reloadConfig(forceConfigUrl: defaultConfigUrl))
     }
 
+    // Before anything can register a window: `MacWindow.getOrRegister` consults it on the very
+    // first adoption, and a miss there is permanent for that window.
+    WorkspaceMemory.load()
+
     checkAccessibilityPermissions()
     startUnixSocketServer()
     GlobalObserver.initObserver()

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -72,6 +72,10 @@ func runRefreshSessionBlocking(
             updateTrayText()
             try await normalizeLayoutReason()
             if shouldLayoutWorkspaces { try await layoutWorkspaces() }
+            // Here rather than only at quit: a crash, a force quit and a `killall -9` never reach
+            // the quit path, and those are the restarts where remembering is worth the most. This
+            // already runs behind the 50ms refresh debounce, so it is once per burst, not per event.
+            WorkspaceMemory.save()
         }
     }
 }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -23,7 +23,13 @@ final class MacWindow: Window {
             windowId,
             macApp,
             isStartup
-                ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
+                // Where this window was before the restart, when it is provably the same window.
+                // Location is the fallback, not the first answer: at a cold start no workspace is
+                // active yet, so the location branch resolves to a stub workspace invented from the
+                // first keybound name in sort order -- which a named workspace like `A` can never be.
+                ? WorkspaceMemory.workspace(forWindowId: windowId, bundleId: macApp.bundleId)
+                    .map { Workspace.get(byName: $0) }
+                    ?? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
                 : focus.workspace,
             window: nil,
         )

--- a/Sources/AppBundle/util/appBundleUtil.swift
+++ b/Sources/AppBundle/util/appBundleUtil.swift
@@ -31,6 +31,10 @@ func initTerminationHandler() {
 
 private struct AppServerTerminationHandler: TerminationHandler {
     func beforeTermination() async throws {
+        // BEFORE the cleanup: it moves every window, which is exactly the information we are
+        // trying to keep. Saving afterwards would record where things were dumped, not where they
+        // belonged.
+        WorkspaceMemory.save()
         try await makeAllWindowsVisibleAndRestoreSize()
         if isDebug {
             sendCommandToReleaseServer(args: ["enable", "on"])

--- a/Sources/AppBundleTests/WorkspaceMemoryTest.swift
+++ b/Sources/AppBundleTests/WorkspaceMemoryTest.swift
@@ -1,0 +1,106 @@
+@testable import AppBundle
+import Common
+import Foundation
+import XCTest
+
+/// The whole risk surface of remembering window→workspace across a restart.
+///
+/// The design deliberately has no fuzzy matching: an exact `CGWindowID`, from this boot, whose app
+/// still matches. So there are only three questions worth asking, and they are all about *refusing*
+/// to restore. A wrong restore moves a window somewhere the user never put it and there is no way
+/// for them to tell it apart from a correct one; a refusal just leaves today's behaviour.
+@MainActor
+final class WorkspaceMemoryTest: XCTestCase {
+    private var stateUrl: URL { URL(filePath: "/tmp/\(aeroSporkAppId)-\(unixUserName).state.json") }
+
+    override func setUp() { try? FileManager.default.removeItem(at: stateUrl) }
+    override func tearDown() { try? FileManager.default.removeItem(at: stateUrl) }
+
+    private func writeState(bootTime: Double, windows: [String: (workspace: String, bundleId: String?)]) {
+        let entries = windows.mapValues { w in
+            w.bundleId.map { ["workspace": w.workspace, "bundleId": $0] } ?? ["workspace": w.workspace]
+        }
+        let json: [String: Any] = ["bootTime": bootTime, "windows": entries]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        try! data.write(to: stateUrl)
+    }
+
+    private var currentBootTime: Double {
+        var tv = timeval()
+        var size = MemoryLayout<timeval>.stride
+        guard sysctlbyname("kern.boottime", &tv, &size, nil, 0) == 0 else { return 0 }
+        return Double(tv.tv_sec)
+    }
+
+    /// The case the guard exists for. `CGWindowID` is documented as unique only *within a user
+    /// session*, so ids are recycled across boots -- and a recycled id matching a stale entry is the
+    /// one way this design could produce a wrong answer instead of no answer.
+    func testStateFromAPreviousBootRestoresNothing() {
+        writeState(bootTime: currentBootTime - 10000, windows: ["42": ("A", "com.apple.finder")])
+        WorkspaceMemory.load()
+
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), nil)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: stateUrl.path),
+            "a file from a previous boot describes ids that mean nothing now; it should be deleted, not kept",
+        )
+    }
+
+    func testStateFromThisBootRestores() {
+        writeState(bootTime: currentBootTime, windows: ["42": ("A", "com.apple.finder")])
+        WorkspaceMemory.load()
+
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), "A")
+    }
+
+    /// Only ids that are actually present are answered for. A window that has gone falls through to
+    /// today's location-based binding.
+    func testAnUnknownWindowIdIsNotAnswered() {
+        writeState(bootTime: currentBootTime, windows: ["42": ("A", "com.apple.finder")])
+        WorkspaceMemory.load()
+
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 99, bundleId: "com.apple.finder"), nil)
+    }
+
+    /// The residual risk the boot guard cannot remove: an id reused *within* one session by a
+    /// different application. One comparison turns it into a no-op.
+    func testAnIdNowOwnedByADifferentAppIsNotAnswered() {
+        writeState(bootTime: currentBootTime, windows: ["42": ("A", "com.apple.finder")])
+        WorkspaceMemory.load()
+
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.googlecode.iterm2"), nil)
+    }
+
+    /// Unknown is not the same as equal. A window whose bundle id we cannot read must not match an
+    /// entry, in either direction.
+    func testAMissingBundleIdIsNeverAMatch() {
+        writeState(bootTime: currentBootTime, windows: ["42": ("A", "com.apple.finder"), "43": ("B", nil)])
+        WorkspaceMemory.load()
+
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: nil), nil)
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 43, bundleId: "com.apple.finder"), nil)
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 43, bundleId: nil), nil)
+    }
+
+    /// No file, or an unreadable one, is simply "no memory" -- the state every first run is in.
+    func testNoFileAndCorruptFileBothRestoreNothing() {
+        WorkspaceMemory.load()
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), nil)
+
+        try! Data("not json".utf8).write(to: stateUrl)
+        WorkspaceMemory.load()
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), nil)
+    }
+
+    /// `load()` is called once at startup; a second call must not leave the previous run's entries
+    /// answering, or a config reload would resurrect stale placement.
+    func testLoadingAgainAfterTheFileIsGoneClearsWhatWasRestored() {
+        writeState(bootTime: currentBootTime, windows: ["42": ("A", "com.apple.finder")])
+        WorkspaceMemory.load()
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), "A")
+
+        try? FileManager.default.removeItem(at: stateUrl)
+        WorkspaceMemory.load()
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), nil)
+    }
+}


### PR DESCRIPTION
Restarting AeroSpork scattered windows: one left on `A` came back on `1` or `3`.

That was structural, not luck. At a cold start no workspace is active, so `getStubWorkspace` invents
one per monitor from the first keybound name in sort order — and `A` sorts after every digit, so it
could **never** be a startup workspace.

## The key is the design

Windows are bound by `CGWindowID` and nothing else.

The WindowServer issues that id and Apple documents it as unique *within the user session*. So it is
exactly stable across a restart of **this process** — the case this exists for, since our lifetime
means nothing to the WindowServer — and worthless once the owning app restarts or the machine reboots.

A composite key (bundle id + title + index + frame) looks like it would cover those cases too. It
cannot. `AXIdentifier` names a window **class**, not an instance — the `axDumps/` fixtures show every
Terminal window reporting `TerminalWindowRestoration` and every Finder window `FinderWindow`. Titles
follow tabs, the index into `kAXWindowsAttribute` is z-order, and our own quit cleanup overwrites the
frame. Three identical terminal windows are genuinely indistinguishable, so a composite key would
shuffle them into an arbitrary permutation — silently, with no test able to catch it, since the
fixtures really are identical.

**An exact id match cannot be wrong. It can only be absent.** That is the trade being made.

## Two guards

- **`kern.boottime`** is stored and the file discarded wholesale if it differs. Ids are recycled
  across boots, and a stale id matching a live window is the one way this design could produce a
  wrong answer rather than no answer.
- **Per-entry bundle id**, checked against the live window's app, which turns within-session reuse
  into a no-op.

## How it degrades

| Situation | Result |
|---|---|
| AeroSpork restarts (update, crash, `killall`, Quit) | windows return to their workspaces |
| Window closed while we were off | entry ignored |
| App relaunched, or machine rebooted | old behaviour — and `on-window-detected` with `if.during-aerospork-startup` is the right tool there, since the user states intent instead of us guessing |
| Monitor unplugged | old behaviour |

Every path degrades to "behaves as before", never to "puts a window somewhere wrong".

## Saving

On the refresh debounce as well as at quit — a crash never reaches the quit path, and that is when
remembering is worth the most — and **before** the quit cleanup, since the cleanup moves every window
and saving after would record where they were dumped rather than where they belonged.

## Tests

Seven, all about *refusing* to restore: stale boot (and that the file is deleted), unknown id, id now
owned by another app, missing bundle id in either direction, no file, corrupt file, and reload
clearing prior state. Mutation-checked — removing the boot guard fails 1, removing the bundle-id
check fails 2.

`./run-tests.sh` green.