### PR TITLE
Stop a window-rule edit destroying config it did not touch

### DIFF
--- a/Sources/AppBundle/config/ConfigurationWriter.swift
+++ b/Sources/AppBundle/config/ConfigurationWriter.swift
@@ -155,7 +155,7 @@ enum ConfigurationWriter {
         if vm.assignmentsEdited { replaceAssignments(&lines, vm, isV2: isV2(base)) }
         if vm.keyMappingEdited { replaceKeyMapping(&lines, vm) }
         if vm.execEdited { replaceExec(&lines, vm) }
-        if vm.windowRulesEdited { replaceWindowRules(&lines, vm) }
+        if vm.windowRulesEdited { replaceWindowRules(&lines, vm, isV2: isV2(base)) }
         applyBindingDiff(&lines, vm, base: base)
 
         // Give the file back the line ending it arrived with. Silently converting a CRLF config to
@@ -190,7 +190,7 @@ enum ConfigurationWriter {
     }
 
     static func unsupportedShapeReason(_ text: String) -> String? {
-        let managedSections = ["gaps", "exec", "key-mapping", "workspace-to-monitor-force-assignment", "monitors"]
+        let managedSections = ["gaps", "exec", "key-mapping", "workspace-to-monitor-force-assignment", "monitors", "on-window"]
         let managedScalars = [
             "start-at-login", "automatically-unhide-macos-hidden-apps",
             "auto-move-workspaces-on-monitor-connect", "enable-normalization-flatten-containers",
@@ -364,7 +364,19 @@ enum ConfigurationWriter {
             && rule.duringStartup == nil
     }
 
-    private static func replaceWindowRules(_ lines: inout [String], _ vm: ConfigurationViewModel) {
+    private static func replaceWindowRules(_ lines: inout [String], _ vm: ConfigurationViewModel, isV2: Bool) {
+        // A rule with no command yet cannot be written -- `run` is required by the parser. Leave the
+        // whole section alone rather than writing the rest, because the alternative is silent
+        // deletion: clearing the Command field to retype it made that rule disappear from disk on
+        // the next 600ms autosave while the row stayed on screen, and every keystroke of the
+        // replacement failed validation and wrote nothing. An interrupted edit lost the rule with no
+        // indication. The same guard covers a value the GUI cannot read at all (`app = 42` loads as
+        // an empty command), which would otherwise be quietly dropped from the user's file.
+        //
+        // Nothing is lost by waiting: the rules on disk keep working, and the edit lands as soon as
+        // the command is complete.
+        guard vm.windowRules.allSatisfy({ !$0.run.trimmingCharacters(in: .whitespaces).isEmpty }) else { return }
+
         removeArrayOfTables(&lines, named: "on-window-detected")
         // The shorthand table too. Removing only the long form left a v2 user's `[on-window]` rules
         // in the file alongside the long-form copy this writes, so every one of them applied twice.
@@ -383,7 +395,7 @@ enum ConfigurationWriter {
         // not run in that order. With no long-form rules there is nothing to take precedence, and
         // app ids are unique, so order genuinely cannot matter.
         let appIds = rules.map(\.appId)
-        if !rules.isEmpty, rules.allSatisfy(isShorthandExpressible), Set(appIds).count == appIds.count {
+        if isV2, !rules.isEmpty, rules.allSatisfy(isShorthandExpressible), Set(appIds).count == appIds.count {
             var block = ["", "[on-window]"]
             for rule in rules.sorted(by: { $0.appId < $1.appId }) {
                 block.append("\(quoted(rule.appId)) = \(tomlArray(splitCommands(rule.run)))")
@@ -407,15 +419,41 @@ enum ConfigurationWriter {
         }
     }
 
+    /// Name of an array-of-table header (`[[on-window-detected]]` -> "on-window-detected"), nil for
+    /// anything else.
+    ///
+    /// Parsed rather than string-compared. `[[ on-window-detected ]]` is legal TOML and TOMLKit
+    /// reads it, so an exact match against `"[[name]]"` left the block in the file while the writer
+    /// appended a fresh one -- two copies of the rule, and since the shorthand is parsed last, the
+    /// *stale* one won. The user's edit did nothing and their config grew on every save.
+    private static func arrayOfTablesHeaderName(_ line: String) -> String? {
+        let t = line.trimmingCharacters(in: .whitespaces)
+        guard t.hasPrefix("[["), t.hasSuffix("]]") else { return nil }
+        return String(t.dropFirst(2).dropLast(2)).trimmingCharacters(in: .whitespaces)
+    }
+
     /// Removes every `[[name]]` block. `removeSections` deliberately ignores array-of-table headers,
     /// so this is a separate walker.
     private static func removeArrayOfTables(_ lines: inout [String], named name: String) {
         var result: [String] = []
         var i = 0
         while i < lines.count {
-            if lines[i].trimmingCharacters(in: .whitespaces) == "[[\(name)]]" {
+            if arrayOfTablesHeaderName(lines[i]) == name {
                 i += 1
-                while i < lines.count, !isHeaderLine(lines[i]) { i += 1 }
+                var end = i
+                while end < lines.count, !isHeaderLine(lines[end]) { end += 1 }
+                // The same rule `removeSections` follows: blank and comment lines immediately before
+                // the next header document THAT header, not the block being removed. Without this,
+                // editing a window rule deleted the banner comment above whatever section came next
+                // -- a section the user never opened, which is exactly what the writer exists to
+                // leave alone.
+                var keepFrom = end
+                while keepFrom > i {
+                    let prev = lines[keepFrom - 1].trimmingCharacters(in: .whitespaces)
+                    if prev.isEmpty || prev.hasPrefix("#") { keepFrom -= 1 } else { break }
+                }
+                result.append(contentsOf: lines[keepFrom ..< end])
+                i = end
             } else {
                 result.append(lines[i])
                 i += 1

--- a/Sources/AppBundleTests/QuitCleanupGeometryTest.swift
+++ b/Sources/AppBundleTests/QuitCleanupGeometryTest.swift
@@ -43,13 +43,27 @@ final class QuitCleanupGeometryTest: XCTestCase {
         XCTAssertEqual(point.y, -1080 + (1080 - 300) / 2)
     }
 
-    /// The main monitor sits at the origin, so this is the case the old code got right -- and the
-    /// reason it survived. Pinned so a "fix" cannot regress it.
-    func testTheMainMonitorIsUnaffected() {
-        let main = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
-        let size = CGSize(width: 1000, height: 700)
+    /// Even the main monitor is offset, so the old code was wrong on a single display too.
+    ///
+    /// What gets passed is `visibleRect`, not `rect`, and the menu bar always insets it: measured on
+    /// a 5120x1440 main display, `visibleRect.topLeftY` is 30, never 0. A Dock on the left insets
+    /// `topLeftX` as well. The old arithmetic therefore put a full-height window's title bar
+    /// *underneath* the menu bar.
+    ///
+    /// A fixture with origin (0,0) would be fiction, and would make this test agree with the old
+    /// code -- which is exactly the wrong thing for it to do.
+    func testEvenTheMainMonitorIsInsetByTheMenuBar() {
+        let menuBarHeight: CGFloat = 30
+        let mainVisible = Rect(topLeftX: 0, topLeftY: menuBarHeight, width: 5120, height: 1440 - menuBarHeight)
+        let fullHeight = CGSize(width: mainVisible.width, height: mainVisible.height)
 
-        assertEquals(centredOnMonitor(main, size), CGPoint(x: (1920 - 1000) / 2, y: (1080 - 700) / 2))
+        // A window sized to the visible area lands exactly on it: both offsets are zero, so the
+        // result is the corner itself.
+        assertEquals(centredOnMonitor(mainVisible, fullHeight), CGPoint(x: 0, y: menuBarHeight))
+        XCTAssertGreaterThanOrEqual(
+            centredOnMonitor(mainVisible, fullHeight).y, menuBarHeight,
+            "a window placed above the menu bar has its title bar covered and cannot be dragged",
+        )
     }
 
     /// A window larger than the monitor centres to a negative offset rather than being clamped;

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -624,13 +624,25 @@ final class ConfigTest: XCTestCase {
     }
 
     /// A config written in the shorthand stays in the shorthand when every rule still fits it.
+    ///
+    /// Rendered against the real base, not `""`. The shorthand is only chosen for a file that is
+    /// already v2 -- `on-window` is a v2 root key, so emitting it into a v1 file would silently
+    /// change that file's schema. An empty base is not v2 and never occurs anyway: with no user
+    /// config, `configBaseText` falls back to the shipped default, which is v2.
     func testShorthandSurvivesAnEditThatStillFitsIt() {
+        let base = """
+            mod = 'alt'
+            workspaces = ['1-9']
+
+            [on-window]
+            "com.apple.finder" = "move-node-to-workspace 3"
+            """
         let vm = ConfigurationViewModel()
-        vm.loadWindowRules(fromText: "[on-window]\n\"com.apple.finder\" = \"move-node-to-workspace 3\"")
+        vm.loadWindowRules(fromText: base)
         vm.markLoaded()
         vm.windowRules.append(.init(appId: "com.apple.mail", run: "layout floating"))
 
-        let out = ConfigurationWriter.render(baseText: "", from: vm)
+        let out = ConfigurationWriter.render(baseText: base, from: vm)
         XCTAssertTrue(out.contains("[on-window]"), "shorthand was converted to long form:\n\(out)")
         XCTAssertFalse(out.contains("[[on-window-detected]]"), out)
     }
@@ -650,6 +662,122 @@ final class ConfigTest: XCTestCase {
         let (config, errors) = parseConfigForTest(out)
         assertEquals(errors, [])
         assertEquals(config.onWindowDetected.count, 2)
+    }
+
+    /// Interior whitespace is legal TOML and TOMLKit reads it, so the GUI listed this rule -- but
+    /// the writer compared the line to the exact string `[[on-window-detected]]` and left it. The
+    /// file then held the old block AND a new one, and since the shorthand parses last, the STALE
+    /// rule won: the edit did nothing and the config grew on every save.
+    func testARuleHeaderWithInteriorSpacesIsStillReplaced() {
+        let base = """
+            [[ on-window-detected ]]
+            if.app-id = 'com.apple.mail'
+            run = ['move-node-to-workspace 3']
+            """
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: base)
+        vm.markLoaded()
+        assertEquals(vm.windowRules.count, 1)
+        vm.windowRules[0].run = "move-node-to-workspace 4"
+
+        let out = ConfigurationWriter.render(baseText: base, from: vm)
+        let (config, errors) = parseConfigForTest(out)
+        assertEquals(errors, [])
+        assertEquals(config.onWindowDetected.count, 1)
+        XCTAssertFalse(out.contains("move-node-to-workspace 3"), "the superseded rule survived:\n\(out)")
+    }
+
+    /// Editing a window rule must not delete the documentation of the section that happens to follow
+    /// it. `removeSections` has always walked back over trailing comments for exactly this reason;
+    /// the array-of-tables walker did not, so a rules edit ate the next section's banner.
+    func testEditingARuleKeepsTheFollowingSectionsComments() {
+        let base = """
+            [[on-window-detected]]
+            if.app-id = 'com.apple.mail'
+            run = ['move-node-to-workspace 3']
+
+            # ---------------------------------------------
+            # Gaps -- tuned for a 32" panel
+            # ---------------------------------------------
+            [gaps]
+            inner.horizontal = 10
+            """
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: base)
+        vm.markLoaded()
+        vm.windowRules[0].run = "move-node-to-workspace 4"
+
+        let out = ConfigurationWriter.render(baseText: base, from: vm)
+        XCTAssertTrue(out.contains("# Gaps -- tuned for a 32\" panel"), "an untouched section lost its comment:\n\(out)")
+        XCTAssertTrue(out.contains("inner.horizontal = 10"), out)
+    }
+
+    /// Choosing the shorthand from the rules alone rewrote a v1 config into v2, because `on-window`
+    /// is a v2 root key -- so retyping a workspace number changed the file's schema, and later saves
+    /// then wrote bindings to a different place than the ones already in the file.
+    func testEditingARuleDoesNotConvertAV1ConfigToV2() {
+        let base = """
+            [mode.main.binding]
+            alt-h = 'focus left'
+
+            [[on-window-detected]]
+            if.app-id = 'com.apple.mail'
+            run = ['move-node-to-workspace 3']
+            """
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: base)
+        vm.markLoaded()
+        vm.windowRules[0].run = "move-node-to-workspace 4"
+
+        let out = ConfigurationWriter.render(baseText: base, from: vm)
+        XCTAssertFalse(out.contains("[on-window]"), "a v1 config was silently converted to v2:\n\(out)")
+        let (config, errors) = parseConfigForTest(out)
+        assertEquals(errors, [])
+        assertEquals(config.onWindowDetected.count, 1)
+    }
+
+    /// Clearing a rule's command to retype it used to delete that rule from the file on the next
+    /// autosave, while the row stayed on screen. Every keystroke of the replacement then failed
+    /// validation and wrote nothing, so an interrupted edit lost the rule silently.
+    func testAHalfTypedCommandDoesNotDeleteTheRulesAlreadyOnDisk() {
+        let base = """
+            mod = 'alt'
+
+            [on-window]
+            "com.apple.finder" = "move-node-to-workspace 3"
+            "com.apple.mail" = "layout floating"
+            """
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: base)
+        vm.markLoaded()
+        assertEquals(vm.windowRules.count, 2)
+        // The user selects the mail rule and clears its Command field, intending to retype it. The
+        // row stays on screen; the question is whether it survives on disk until they finish.
+        vm.windowRules[1].run = ""
+
+        let out = ConfigurationWriter.render(baseText: base, from: vm)
+        let (config, errors) = parseConfigForTest(out)
+        assertEquals(errors, [])
+        assertEquals(config.onWindowDetected.count, 2)
+        XCTAssertTrue(out.contains("layout floating"), "the rule being retyped was deleted from disk:\n\(out)")
+    }
+
+    /// Same guard, reached from a value the GUI cannot represent: `= 42` reads as an empty command,
+    /// and dropping it would silently delete a line the user wrote.
+    func testAnUnreadableRuleValueIsNotSilentlyDropped() {
+        let base = """
+            mod = 'alt'
+
+            [on-window]
+            "com.apple.finder" = 42
+            """
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: base)
+        vm.markLoaded()
+        vm.windowRules.append(.init(appId: "com.apple.mail", run: "layout floating"))
+
+        let out = ConfigurationWriter.render(baseText: base, from: vm)
+        XCTAssertTrue(out.contains("42"), "a line the GUI could not read was deleted:\n\(out)")
     }
 
     /// An *applied* Raw TOML tab is authoritative -- it is exactly what lands on disk.


### PR DESCRIPTION
Found by adversarially reviewing #14. Four defects, two of which lose file content, plus a test of
mine that was asserting the wrong thing.

## `[[ on-window-detected ]]` was never removed

The writer compared the line to that exact string; TOMLKit accepts interior spaces. So the GUI listed
the rule and the writer could not delete it — the file kept the old block **and** gained a new one,
and since the shorthand parses last, the **stale** rule won. The edit did nothing and the config grew
on every save. That is the same bug #14 set out to fix, through a different spelling. Headers are
parsed now.

## A rules edit deleted the *next* section's comments

`removeSections` has always walked back over trailing blank/comment lines, with a comment explaining
they document the following header and that swallowing them "broke the whole untouched-sections-are-
left-alone promise". `removeArrayOfTables` never did. Editing a window rule ate the banner above
whatever section came next — one the user never opened.

## Editing a rule converted a v1 config to v2

Shorthand was chosen from the rules alone, but `on-window` is a v2 root key. Retyping a workspace
number rewrote the file's schema, after which new bindings write to `[keys]` while the existing ones
sit in `[mode.main.binding]`. Now conditional on the file already being v2.

## Clearing a Command field deleted that rule from disk

Empty-`run` rules are skipped by the writer but kept on screen. Clearing the field to retype it
deleted the rule on the next autosave, and every keystroke of the replacement failed validation and
wrote nothing — an interrupted edit lost it silently. The section is now left alone until every rule
has a command, which also stops a value the GUI cannot read (`app = 42`) being dropped.

Plus `on-window` in `managedSections`, so a dotted or inline spelling is refused up front instead of
producing a file that fails validation on every save.

## A test of mine was wrong

`testShorthandSurvivesAnEditThatStillFitsIt` rendered against `baseText: ""`, which is not v2 and
never occurs — with no user config the base is the shipped default, which is v2.

Also here: `testTheMainMonitorIsUnaffected` used a fixture with origin `(0,0)` and called it the main
monitor. The menu bar makes that impossible — measured `visibleRect.topLeftY` is 30 on the reporting
machine. It asserted the one input where the *broken* arithmetic is right, so it passed on both
versions. With a realistic fixture all four geometry tests fail on the old code instead of three.

All new tests mutation-checked. `./run-tests.sh` green.