### PR TITLE
Bring the design kit's strings back in step with the Swift

### DIFF
--- a/.claude/skills/aerospork-design/components/controls/Select.prompt.md
+++ b/.claude/skills/aerospork-design/components/controls/Select.prompt.md
@@ -3,7 +3,7 @@ Use for a list of options that can grow at runtime (connected monitors, modes, k
 ```jsx
 <Select value={monitor} onChange={setMonitor} options={[
   { value: 'main', label: 'Primary' },
-  { value: 'secondary', label: 'Non-primary' },
+  { value: 'secondary', label: 'Non-main' },
   { separator: true },
   { value: 'DELL U2720Q', label: 'DELL U2720Q' },
 ]} />

--- a/.claude/skills/aerospork-design/components/controls/controls.card.html
+++ b/.claude/skills/aerospork-design/components/controls/controls.card.html
@@ -35,7 +35,7 @@ function Card() {
       </div>
       <div className="col"><span className="lbl">Pickers</span>
         <SegmentedPicker options={['Tiles', 'Accordion']} value={layout} onChange={setLayout} />
-        <Select value="main" options={[{ value: 'main', label: 'Primary' }, { value: 'secondary', label: 'Non-primary' }]} width={150} />
+        <Select value="main" options={[{ value: 'main', label: 'Main' }, { value: 'secondary', label: 'Non-main' }]} width={150} />
       </div>
       <div className="col"><span className="lbl">Key recorder</span>
         <KeyRecorderField notation="alt-shift-h" showsClear={false} />

--- a/.claude/skills/aerospork-design/components/feedback/ContentUnavailable.prompt.md
+++ b/.claude/skills/aerospork-design/components/feedback/ContentUnavailable.prompt.md
@@ -3,7 +3,7 @@ Use for every empty list, empty filter result and unselected detail pane — a s
 ~~~jsx
 <ContentUnavailable sf="arrow.triangle.branch" title="No assignments"
   message="Workspaces land wherever they were last used. Add an assignment to pin one to a specific monitor."
-  actionTitle="Add Assignment" onAction={add} />
+  actionTitle="Add assignment" onAction={add} />
 ~~~
 
 The message teaches the feature; only offer an action when this pane can create the first item.

--- a/.claude/skills/aerospork-design/components/feedback/feedback.card.html
+++ b/.claude/skills/aerospork-design/components/feedback/feedback.card.html
@@ -32,7 +32,7 @@ function Card() {
         <div style={{ flex: 1, background: 'var(--control-bg)', borderRadius: 8, boxShadow: '0 0 0 0.5px var(--separator)', height: 190 }}>
           <ContentUnavailable sf="arrow.triangle.branch" title="No assignments"
             message="Workspaces land wherever they were last used. Add an assignment to pin one to a specific monitor."
-            actionTitle="Add Assignment" />
+            actionTitle="Add assignment" />
         </div>
       </div>
     </div>

--- a/.claude/skills/aerospork-design/components/layout/DataTable.prompt.md
+++ b/.claude/skills/aerospork-design/components/layout/DataTable.prompt.md
@@ -3,5 +3,5 @@ Use for editable lists with more than one field per row (workspace assignments, 
 ~~~jsx
 <DataTable selected={sel} onSelect={setSel} rows={rules}
   columns={[{ key: 'match', title: 'Matches', width: '1fr' }, { key: 'run', title: 'Run' }]}
-  emptyState={<ContentUnavailable sf="macwindow" title="No window rules" message="Rules run once, when a window first appears." actionTitle="Add Rule" onAction={add} />} />
+  emptyState={<ContentUnavailable sf="macwindow" title="No window rules" message="Rules run once, when a window first appears." actionTitle="Add rule" onAction={add} />} />
 ~~~

--- a/.claude/skills/aerospork-design/components/layout/MenuPanel.prompt.md
+++ b/.claude/skills/aerospork-design/components/layout/MenuPanel.prompt.md
@@ -4,7 +4,7 @@ Use for the menu bar menu. Keep it a remote control: only what you reach for wit
 <MenuPanel items={[
   { label: '1', mono: true, checked: true, suffix: ' — Built-in' },
   { divider: true },
-  { label: 'Pause Tiling', shortcut: '⌘E' },
+  { label: 'Pause tiling', shortcut: '⌘E' },
   { label: 'Settings…', shortcut: '⌘,' },
 ]} />
 ~~~

--- a/.claude/skills/aerospork-design/components/layout/SectionLabel.prompt.md
+++ b/.claude/skills/aerospork-design/components/layout/SectionLabel.prompt.md
@@ -1,4 +1,4 @@
-Use as the header of every FormSection and of any list pane. Sentence case, no trailing punctuation ("Startup & Behaviour", "Connected monitors").
+Use as the header of every FormSection and of any list pane. Sentence case, no trailing punctuation ("Startup & behaviour", "Connected monitors").
 
 ~~~jsx
 <SectionLabel title="Between windows" sf="rectangle.split.2x1" />

--- a/.claude/skills/aerospork-design/components/layout/layout.card.html
+++ b/.claude/skills/aerospork-design/components/layout/layout.card.html
@@ -54,7 +54,7 @@ function Card() {
         <MenuPanel width={210} items={[
           { label: '1', mono: true, checked: true }, { label: '2', mono: true }, { label: 'web', mono: true },
           { divider: true },
-          { label: 'Pause Tiling', shortcut: '⌘E' }, { divider: true },
+          { label: 'Pause tiling', shortcut: '⌘E' }, { divider: true },
           { label: 'Settings…', shortcut: '⌘,' }, { label: 'Quit AeroSpork', shortcut: '⌘Q' },
         ]} />
       </div>

--- a/.claude/skills/aerospork-design/ui_kits/menu_bar/MenuBarKit.jsx
+++ b/.claude/skills/aerospork-design/ui_kits/menu_bar/MenuBarKit.jsx
@@ -49,7 +49,7 @@ function MenuBarKit() {
       onClick: () => { setWorkspace(n); setOpen(false); },
     })),
     { divider: true },
-    { label: enabled ? 'Pause Tiling' : 'Resume Tiling', shortcut: '⌘E', onClick: () => { setEnabled(!enabled); setOpen(false); } },
+    { label: enabled ? 'Pause tiling' : 'Resume tiling', shortcut: '⌘E', onClick: () => { setEnabled(!enabled); setOpen(false); } },
     { divider: true },
     { label: 'Settings…', shortcut: '⌘,', onClick: () => { window.open('../settings_app/index.html', '_blank'); setOpen(false); } },
     { label: 'Quit AeroSpork', shortcut: '⌘Q', onClick: () => setOpen(false) },

--- a/.claude/skills/aerospork-design/ui_kits/menu_bar/README.md
+++ b/.claude/skills/aerospork-design/ui_kits/menu_bar/README.md
@@ -8,7 +8,7 @@ desktop so the chips have something to describe.
 - **The menu is a remote control**: jump to a workspace, leave a mode, pause tiling, Settings, Quit.
   Everything that is configuration lives in Settings — that is why there is no "Reload config" or
   "Open config" row here.
-- **Pause Tiling** swaps the label for `pause.circle.fill` and lets the windows float, which is
+- **Pause tiling** swaps the label for `pause.circle.fill` and lets the windows float, which is
   what the real command does.
 - The "service" mode link shows the capsule chip and the *Leave mode* row that only appears while a
   non-main mode is active.

--- a/.claude/skills/aerospork-design/ui_kits/settings_app/GeneralTab.jsx
+++ b/.claude/skills/aerospork-design/ui_kits/settings_app/GeneralTab.jsx
@@ -3,7 +3,7 @@ const { FormSection, SectionLabel, LabeledContent, Toggle, SegmentedPicker, Sele
 function GeneralTab({ s, set }) {
   return (
     <div className="form-page">
-      <FormSection header={<SectionLabel title="Startup & Behaviour" sf="power" />}>
+      <FormSection header={<SectionLabel title="Startup & behaviour" sf="power" />}>
         <Toggle label="Start AeroSpork at login" checked={s.startAtLogin} onChange={(v) => set('startAtLogin', v)} />
         <Toggle label="Automatically unhide macOS hidden apps" checked={s.unhide} onChange={(v) => set('unhide', v)}
           help="Undo Command-H automatically, so hidden windows keep tiling" />

--- a/.claude/skills/aerospork-design/ui_kits/settings_app/MonitorsTab.jsx
+++ b/.claude/skills/aerospork-design/ui_kits/settings_app/MonitorsTab.jsx
@@ -4,7 +4,7 @@ function MonitorsTab({ monitors, assignments, setAssignments }) {
   const [selected, setSelected] = React.useState(null);
   const monitorOptions = [
     { value: 'main', label: 'Primary' },
-    { value: 'secondary', label: 'Non-primary' },
+    { value: 'secondary', label: 'Non-main' },
     { separator: true },
     ...monitors.flatMap((m) => [{ value: m.name, label: m.name }, { value: m.uuid, label: m.name + ' — exact display' }]),
   ];
@@ -42,7 +42,7 @@ function MonitorsTab({ monitors, assignments, setAssignments }) {
           rows={assignments}
           emptyState={<ContentUnavailable sf="arrow.triangle.branch" title="No assignments"
             message="Workspaces land wherever they were last used. Add an assignment to pin one to a specific monitor."
-            actionTitle="Add Assignment" onAction={add} />} />
+            actionTitle="Add assignment" onAction={add} />} />
       </div>
       <ListActionBar addHelp="Pin a workspace to a monitor" removeHelp="Remove the selected assignment"
         onAdd={add} onRemove={selected ? remove : null}

--- a/.claude/skills/aerospork-design/ui_kits/settings_app/RulesTab.jsx
+++ b/.claude/skills/aerospork-design/ui_kits/settings_app/RulesTab.jsx
@@ -36,7 +36,7 @@ function RulesTab({ rules, setRules }) {
           ]}
           emptyState={<ContentUnavailable sf="macwindow" title="No window rules"
             message="Rules run once, when a window first appears — the usual use is sending an app straight to its workspace."
-            actionTitle="Add Rule" onAction={add} />} />
+            actionTitle="Add rule" onAction={add} />} />
         <ListActionBar addHelp="Add a window rule" removeHelp="Remove the selected rule" onAdd={add} onRemove={selected ? remove : null} />
       </div>
       <div className="split-detail">


### PR DESCRIPTION
The kit under `.claude/skills/aerospork-design/` is a recreation of the shipping SwiftUI, derived from
it — so when #14 corrected the Swift to sentence case, the kit was left showing the old Title Case.

Updated: `Add Rule`, `Add Assignment`, `Startup & Behaviour`, `Pause Tiling`/`Resume Tiling`, and the
`Primary`/`Non-primary` monitor labels that `docs/guide.adoc` and macOS both call **main**.

Two prompt docs cited the offending strings as *examples of the rule they broke* —
`SectionLabel.prompt.md` used "Startup & Behaviour" to illustrate sentence case — so those are
corrected alongside.

`Window Rules` is deliberately left: `TabBar.prompt.md` names it as the one two-word tab, and the
Swift agrees.

Docs and mock assets only; no production code.