### PR TITLE
Publish 1.1.4 in the appcast

### DIFF
--- a/updates-site/appcast.xml
+++ b/updates-site/appcast.xml
@@ -6,6 +6,15 @@
         <description>Updates for AeroSpork, an i3-like tiling window manager for macOS.</description>
         <language>en</language>
         <item>
+            <title>1.1.4</title>
+            <pubDate>Thu, 30 Jul 2026 12:32:06 -0500</pubDate>
+            <link>https://github.com/wbsmolen/aerospork</link>
+            <sparkle:version>1.1.4</sparkle:version>
+            <sparkle:shortVersionString>1.1.4</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.4/AeroSpork-1.1.4.zip" length="6250094" type="application/octet-stream" sparkle:edSignature="Gbv8FYEh6gkvwiDd5I4W3PXtPkeqD5AI2znn85hCqmdZlU+jmr9gtdjY5KLheTa6LUD6kMqmtJmBW5m0v6JvCg=="/>
+        </item>
+        <item>
             <title>1.1.3</title>
             <pubDate>Thu, 30 Jul 2026 11:23:45 -0500</pubDate>
             <link>https://github.com/wbsmolen/aerospork</link>
@@ -22,15 +31,6 @@
             <sparkle:shortVersionString>1.1.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
             <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.2/AeroSpork-1.1.2.zip" length="6244875" type="application/octet-stream" sparkle:edSignature="FNi2ixPS0TcZ+XdjFCA4BQ9uKPwk1mnpST75MGU0qNQD1exb0nIahx52aG/8frSfuTGx6B4bBuWeCVsk2VKTDA=="/>
-        </item>
-        <item>
-            <title>1.1.1</title>
-            <pubDate>Thu, 30 Jul 2026 09:35:23 -0500</pubDate>
-            <link>https://github.com/wbsmolen/aerospork</link>
-            <sparkle:version>1.1.1</sparkle:version>
-            <sparkle:shortVersionString>1.1.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.1/AeroSpork-1.1.1.zip" length="6227539" type="application/octet-stream" sparkle:edSignature="EL1urCWCCBXgeIaQSn3wRQ7TEH3ruXu1Ar9ELfvGukGEmIAd4vy+cQ4MlRZKIGVFE49FunYaJw4SxmVbGMU0CA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
`generate_appcast` pruned the 1.1.1 item. Clients always take the newest applicable one, so a 1.1.1 install still upgrades straight to 1.1.4.

Verified against the asset GitHub actually serves: `sign_update --verify` exits 0 for `AeroSpork-1.1.4.zip` and non-zero for the distribution zip.