### PR TITLE
Report failure when open-settings has nothing to open

### DIFF
--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -144,6 +144,12 @@ func settingsBridged(_ content: some View) -> some View {
         settingsOpener()
         return true
     }
+    // On 14+ a nil opener means the menu bar label has not rendered yet -- `aerospork
+    // open-settings` in the first seconds after launch lands here. Report that, rather than
+    // falling through to the selector below: `sendAction` returns true for it while opening
+    // nothing, which is the exact silent success this function was rewritten to stop. The command
+    // then exits 0 having done nothing visible.
+    if #available(macOS 14, *) { return false }
     // macOS 13 has no `\.openSettings`. The pre-Ventura selector is still the only route there.
     return NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
 }

--- a/Sources/AppBundleTests/OpenSettingsTest.swift
+++ b/Sources/AppBundleTests/OpenSettingsTest.swift
@@ -1,0 +1,64 @@
+@testable import AppBundle
+import XCTest
+
+/// `open-settings` must not report success when it opened nothing.
+///
+/// The settings window is opened through `\.openSettings`, which is only readable inside a view, so
+/// the menu bar label captures it into `settingsOpener` when it appears. Until that happens the
+/// opener is nil -- a window of a few seconds after launch, which `aerospork open-settings` can land
+/// in.
+///
+/// The nil branch used to fall through to the pre-Ventura `showPreferencesWindow:` selector.
+/// `sendAction` returns true for it on macOS 14+ while opening nothing, so the command exited 0
+/// having done nothing visible: exactly the silent success this whole path was rewritten to remove,
+/// reintroduced through the fallback. Measured against a real 1.1.4 build, eight seconds after
+/// launch: exit 0, zero windows.
+@MainActor
+final class OpenSettingsTest: XCTestCase {
+    private var saved: (() -> Void)?
+
+    override func setUp() {
+        saved = settingsOpener
+    }
+
+    override func tearDown() {
+        settingsOpener = saved
+    }
+
+    /// The regression, pinned by reading the source rather than by calling it.
+    ///
+    /// Calling `openSettingsWindow()` with a nil opener cannot distinguish the two versions here:
+    /// in a headless test process there is no responder chain, so `sendAction` returns false and the
+    /// buggy code returns false too. The behavioural test passes either way — verified by putting
+    /// the fallthrough back and watching it stay green — so it would have been a test that only
+    /// looked like coverage. The difference exists solely in a real app, where `sendAction` returns
+    /// true for a selector that opens nothing.
+    func testTheSelectorFallbackIsNotReachedOnModernMacOS() throws {
+        let source = try String(
+            contentsOf: projectRoot.appending(path: "Sources/AppBundle/ui/MenuBar.swift"),
+            encoding: .utf8,
+        )
+        let body = try XCTUnwrap(
+            source.range(of: "func openSettingsWindow()").map { String(source[$0.lowerBound...].prefix(900)) },
+            "openSettingsWindow() not found",
+        )
+        let guardIndex = try XCTUnwrap(body.range(of: "#available(macOS 14, *) { return false }")?.lowerBound)
+        let selectorIndex = try XCTUnwrap(body.range(of: "showPreferencesWindow:")?.lowerBound)
+        XCTAssertLessThan(
+            guardIndex, selectorIndex,
+            """
+            macOS 14+ must return false before reaching the pre-Ventura selector. sendAction returns
+            true for it while opening nothing, so `open-settings` exits 0 having done nothing visible.
+            """,
+        )
+    }
+
+    /// And when it has been captured, it is used and reported as success.
+    func testUsesTheCapturedOpenerAndReportsSuccess() {
+        var called = 0
+        settingsOpener = { called += 1 }
+
+        XCTAssertTrue(openSettingsWindow())
+        assertEquals(called, 1)
+    }
+}


### PR DESCRIPTION
`aerospork open-settings` in the first seconds after launch exited `0` and opened nothing. Measured
against a real 1.1.4 build, eight seconds after launch: exit 0, zero windows. A second call a moment
later worked.

`\.openSettings` is only readable inside a view, so the menu bar label captures it into
`settingsOpener` on appear. Until that happens the opener is nil — and that branch fell through to
the pre-Ventura `showPreferencesWindow:` selector, which `sendAction` reports as handled on macOS 14+
while opening nothing.

That is precisely the silent success #8 rewrote this function to remove, reintroduced through its own
fallback. On 14+ a nil opener is now a reported failure. macOS 13 still uses the selector, where it is
the only route.

## The obvious test for this is a lie

Calling `openSettingsWindow()` with a nil opener returns `false` **either way** in a headless test
process — there is no responder chain for `sendAction` to find, so the buggy version returns false
too. I wrote that test, put the bug back, and watched it stay green. It would have been coverage in
appearance only.

Pinned by reading the source instead: the `#available(macOS 14, *) { return false }` guard must
precede the selector. That version does fail on the old arrangement. The second test — captured
opener is used and reported as success — is behavioural and meaningful.

## Also checked

With `show-menu-bar-icon = false` the label still renders, so the opener is captured and the command
works. I expected this to be broken and it is not.

`./run-tests.sh` green.