### PR TITLE
Clear the rest of the settings audit findings

### DIFF
--- a/Sources/AppBundle/ui/ConfigurationTabs/CallbacksTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/CallbacksTab.swift
@@ -70,9 +70,7 @@ struct CallbacksTab: View {
     ) -> some View {
         Section {
             if viewModel[keyPath: keyPath].isEmpty {
-                Text("Nothing runs on this event.")
-                    .font(.callout)
-                    .foregroundStyle(.tertiary)
+                SettingsHint("Nothing here yet. Anything you add runs every time this event fires — `exec-and-forget` for a shell command, or an aerospork command directly.")
             }
             ForEach(viewModel[keyPath: keyPath]) { row in
                 HStack(spacing: 8) {
@@ -106,6 +104,7 @@ struct CallbacksTab: View {
             .buttonStyle(.borderless)
             .foregroundStyle(.secondary)
             .help("Remove")
+            .accessibilityLabel("Remove")
     }
 
     private func commandBinding(

--- a/Sources/AppBundle/ui/ConfigurationTabs/GapsSettingsTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/GapsSettingsTab.swift
@@ -46,7 +46,11 @@ struct GapsSettingsTab: View {
             // Plain prose, no backticks: a markdown code span containing brackets makes SwiftUI's
             // parser fail and fall back to the literal string, backticks included.
             SettingsFooter(
-                "Per-monitor gaps such as outer.top = [{ monitor.main = 16 }, 8] survive untouched until you change one of these — editing any gap rewrites the whole gaps section. Use Raw TOML for per-monitor rules.",
+                // Reworded so the config key fits in a code span. SwiftUI's markdown parser reads the
+                // `[` of an array inside backticks as the start of a link, fails, and falls back to
+                // the literal text -- backticks and all -- so the previous wording had to spell the
+                // array out in body font, which is the face this window reserves for prose.
+                "Per-monitor gaps, such as a list of values under `outer.top`, survive untouched until you change one of these — editing any gap rewrites the whole gaps section. Use Raw TOML for per-monitor rules.",
             )
         }
     }

--- a/Sources/AppBundle/ui/ConfigurationTabs/KeyBindingsTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/KeyBindingsTab.swift
@@ -80,7 +80,9 @@ struct KeyBindingsTab: View {
                 Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
                 TextField("Filter", text: $query)
                     .textFieldStyle(.plain)
-                    .frame(width: 150)
+                    // Compressible. The mode picker beside it is `.fixedSize()`, so at the 780pt
+                    // minimum width a handful of modes pushed a hard-150pt filter box off the edge.
+                    .frame(minWidth: 70, idealWidth: 150)
                     .accessibilityLabel("Filter bindings")
                 if !query.isEmpty {
                     Button { query = "" } label: { Image(systemName: "xmark.circle.fill") }
@@ -115,6 +117,9 @@ struct KeyBindingsTab: View {
                 message: query.isEmpty
                     ? "Record a shortcut below to add the first one."
                     : "Nothing in “\(selectedMode)” matches “\(query)”.",
+                // The query is whatever the user typed; markdown would render `*foo*` as italic foo
+                // rather than the text they are actually searching for.
+                messageIsMarkdown: query.isEmpty,
             )
         } else {
             List {
@@ -326,6 +331,7 @@ private struct KeyRecorderField: View {
                         .foregroundStyle(.tertiary)
                         .padding(.trailing, 4)
                         .help("Clear")
+                        .accessibilityLabel("Clear this shortcut")
                 }
             }
     }
@@ -397,12 +403,28 @@ private struct KeyRecorderField: View {
             path.stroke()
 
             let text = !displayed.isEmpty ? KeyNotation.pretty(displayed) : (recording ? "Press a shortcut…" : "Click to record")
+            // Monospace is for the captured notation -- something the user could type into their
+            // config. The instructional placeholder is prose and takes the system face, the same
+            // split the colour below already makes.
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.lineBreakMode = .byTruncatingTail
             let attrs: [NSAttributedString.Key: Any] = [
-                .font: NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular),
+                .font: displayed.isEmpty
+                    ? NSFont.systemFont(ofSize: NSFont.systemFontSize)
+                    : NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular),
                 .foregroundColor: displayed.isEmpty ? NSColor.placeholderTextColor : NSColor.labelColor,
+                .paragraphStyle: paragraph,
             ]
             let size = (text as NSString).size(withAttributes: attrs)
-            (text as NSString).draw(at: NSPoint(x: 8, y: (bounds.height - size.height) / 2), withAttributes: attrs)
+            // `draw(in:)`, not `draw(at:)`: without a bounding rect AppKit clips at the view edge
+            // mid-glyph with no ellipsis, and a binding like `alt-shift-leftSquareBracket` is wider
+            // than the 150pt field.
+            let inset: CGFloat = 8
+            (text as NSString).draw(
+                in: NSRect(x: inset, y: (bounds.height - size.height) / 2,
+                           width: max(0, bounds.width - inset * 2), height: size.height),
+                withAttributes: attrs,
+            )
         }
     }
 }

--- a/Sources/AppBundle/ui/ConfigurationTabs/WindowRulesTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/WindowRulesTab.swift
@@ -4,6 +4,9 @@ import SwiftUI
 /// `[[on-window-detected]]` — assign windows to workspaces, float them, etc. when they appear.
 /// Typically the most-configured feature after keybindings, and previously invisible to the GUI.
 struct WindowRulesTab: View {
+    /// Shown for a rule with no matchers at all. Prose, not config text -- see `matchCell`.
+    private static let anyWindow = "(any window)"
+
     @ObservedObject var viewModel: ConfigurationViewModel
     @State private var selection: ConfigurationViewModel.WindowRuleRow.ID?
 
@@ -62,7 +65,11 @@ struct WindowRulesTab: View {
     @ViewBuilder
     private func matchCell(_ rule: ConfigurationViewModel.WindowRuleRow) -> some View {
         HStack(spacing: 5) {
-            Text(summary(rule)).font(.system(.body, design: .monospaced))
+            // Monospace only for a real matcher, which is config text. "(any window)" is prose
+            // describing an absence, and reading it as something pasteable is misleading.
+            Text(summary(rule))
+                .font(summary(rule) == Self.anyWindow ? .body : .system(.body, design: .monospaced))
+                .foregroundStyle(summary(rule) == Self.anyWindow ? .secondary : .primary)
             // The UI has no control for `during-aerospork-startup`, but it round-trips it. Say so,
             // or a rule that only fires at startup looks identical to one that fires every time.
             if rule.duringStartup == true {
@@ -142,7 +149,7 @@ struct WindowRulesTab: View {
         if !r.appNameRegex.isEmpty { parts.append("name~\(r.appNameRegex)") }
         if !r.windowTitleRegex.isEmpty { parts.append("title~\(r.windowTitleRegex)") }
         if !r.workspace.isEmpty { parts.append("ws=\(r.workspace)") }
-        return parts.isEmpty ? "(any window)" : parts.joined(separator: " ")
+        return parts.isEmpty ? Self.anyWindow : parts.joined(separator: " ")
     }
 
     private func field(_ i: Int, _ keyPath: WritableKeyPath<ConfigurationViewModel.WindowRuleRow, String>) -> Binding<String> {

--- a/Sources/AppBundle/ui/ConfigurationTabs/WorkspacesMonitorsTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/WorkspacesMonitorsTab.swift
@@ -37,7 +37,7 @@ struct WorkspacesMonitorsTab: View {
             // Same empty-state treatment as every other list in this window, rather than a section
             // header floating above nothing.
             if viewModel.liveMonitors.isEmpty {
-                SettingsHint("No monitors reported yet.")
+                SettingsHint("No monitors reported yet — they appear as soon as macOS reports one, and their UUIDs are what pins a workspace to a physical panel.")
                     .padding(.horizontal, 16)
                     .padding(.bottom, 14)
             }
@@ -101,7 +101,9 @@ struct WorkspacesMonitorsTab: View {
                     .width(min: 110, ideal: 140)
 
                     TableColumn("Monitor") { row in
-                        Picker("", selection: binding(row.id, \.monitor)) {
+                        // A Table column header is not a control label, so without this the
+                        // picker is announced as an unnamed pop-up button.
+                        Picker("Monitor for this workspace", selection: binding(row.id, \.monitor)) {
                             Text("Main").tag("main")
                             Text("Non-main").tag("secondary")
                             Divider()

--- a/Sources/AppBundle/ui/SettingsChrome.swift
+++ b/Sources/AppBundle/ui/SettingsChrome.swift
@@ -39,8 +39,11 @@ struct NumberField: View {
                 Text(unit)
                     .foregroundStyle(.secondary)
                     .font(.callout)
-                Stepper("", value: clamped, in: range)
+                // Separately focusable, so it needs a name of its own: `LabeledContent` labels the
+                // row, not the second control inside it.
+                Stepper(title, value: clamped, in: range)
                     .labelsHidden()
+                    .accessibilityLabel(title)
             }
         }
     }
@@ -165,6 +168,10 @@ struct ContentUnavailableViewCompat: View {
     let icon: String
     let title: String
     let message: String
+    /// `message` is rendered as markdown so a static one can carry `code` spans. Pass `false` when
+    /// it interpolates anything the user typed: a filter query of `*foo*` would otherwise come back
+    /// italicised instead of as the literal text they are looking for.
+    var messageIsMarkdown = true
     var actionTitle: String?
     var action: (() -> Void)?
 
@@ -176,7 +183,7 @@ struct ContentUnavailableViewCompat: View {
                 .padding(.bottom, 2)
             Text(title).font(.headline)
             // Markdown, so `code` spans in an empty-state message don't read as literal backticks.
-            Text(LocalizedStringKey(message))
+            (messageIsMarkdown ? Text(LocalizedStringKey(message)) : Text(verbatim: message))
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)


### PR DESCRIPTION
The remaining findings from the two settings audits, none of which were blocking on their own.

**Accessibility.** The monitor picker and every `NumberField` stepper had an empty-string label — a Table column header labels the column, not the control; `LabeledContent` labels the row, not the second control in it. The icon-only Remove and Clear buttons had tooltips but no accessible name.

**The shortcut recorder** drew with `draw(at:)`, which has no bounding rect, so AppKit clipped long bindings mid-glyph with no ellipsis — `alt-shift-leftSquareBracket` is wider than the 150pt field. It also drew its instructional placeholder in the monospace face reserved for captured notation.

**The bindings filter** was a hard 150pt beside a `.fixedSize()` mode picker, so ~5 modes pushed it off the window edge at the 780pt minimum.

**Markdown over runtime text** — a filter query of `*foo*` rendered as italic *foo* instead of what the user typed. Interpolated messages now opt out.

**Copy.** Two hints announced emptiness instead of teaching the feature; a gaps hint spelled a TOML fragment in body font because SwiftUI's markdown parser chokes on `[` inside a code span (reworded so the key fits in one); and `(any window)` is prose but was drawn as pasteable config text.

`./run-tests.sh` green.