### PR TITLE
Cap the bindings filter box, which was swallowing the toolbar

### DIFF
--- a/.claude/skills/aerospork-design/_ds_bundle.js
+++ b/.claude/skills/aerospork-design/_ds_bundle.js
@@ -1634,7 +1634,7 @@ function MenuBarKit() {
   })), {
     divider: true
   }, {
-    label: enabled ? 'Pause Tiling' : 'Resume Tiling',
+    label: enabled ? 'Pause tiling' : 'Resume tiling',
     shortcut: '⌘E',
     onClick: () => {
       setEnabled(!enabled);
@@ -1920,7 +1920,7 @@ function CommandRows({
       fontSize: 'var(--text-callout)',
       color: 'var(--label-tertiary)'
     }
-  }, "Nothing runs on this event.") : /*#__PURE__*/React.createElement("div", {
+  }, "Nothing here yet. Anything you add runs every time this event fires — exec-and-forget for a shell command, or an aerospork command directly.") : /*#__PURE__*/React.createElement("div", {
     key: i,
     style: {
       display: 'flex',
@@ -2131,7 +2131,7 @@ function GapsTab({
     title: "Right",
     value: s.outerRight,
     onChange: v => set('outerRight', v)
-  }))), /*#__PURE__*/React.createElement(SettingsFooter, null, "Per-monitor gaps such as outer.top = [", '{', " monitor.main = 16 ", '}', ", 8] survive untouched until you change one of these \u2014 editing any gap rewrites the whole gaps section. Use Raw TOML for per-monitor rules."));
+  }))), /*#__PURE__*/React.createElement(SettingsFooter, null, "Per-monitor gaps, such as a list of values under outer.top, = [", '{', " monitor.main = 16 ", '}', ", 8] survive untouched until you change one of these \u2014 editing any gap rewrites the whole gaps section. Use Raw TOML for per-monitor rules."));
 }
 Object.assign(window, {
   GapsTab
@@ -2158,7 +2158,7 @@ function GeneralTab({
     className: "form-page"
   }, /*#__PURE__*/React.createElement(FormSection, {
     header: /*#__PURE__*/React.createElement(SectionLabel, {
-      title: "Startup & Behaviour",
+      title: "Startup & behaviour",
       sf: "power"
     })
   }, /*#__PURE__*/React.createElement(Toggle, {
@@ -2528,10 +2528,10 @@ function MonitorsTab({
   const [selected, setSelected] = React.useState(null);
   const monitorOptions = [{
     value: 'main',
-    label: 'Primary'
+    label: 'Main'
   }, {
     value: 'secondary',
-    label: 'Non-primary'
+    label: 'Non-main'
   }, {
     separator: true
   }, ...monitors.flatMap(m => [{
@@ -2653,7 +2653,7 @@ function MonitorsTab({
       sf: "arrow.triangle.branch",
       title: "No assignments",
       message: "Workspaces land wherever they were last used. Add an assignment to pin one to a specific monitor.",
-      actionTitle: "Add Assignment",
+      actionTitle: "Add assignment",
       onAction: add
     })
   })), /*#__PURE__*/React.createElement(ListActionBar, {
@@ -2851,7 +2851,7 @@ function RulesTab({
       sf: "macwindow",
       title: "No window rules",
       message: "Rules run once, when a window first appears \u2014 the usual use is sending an app straight to its workspace.",
-      actionTitle: "Add Rule",
+      actionTitle: "Add rule",
       onAction: add
     })
   }), /*#__PURE__*/React.createElement(ListActionBar, {

--- a/.claude/skills/aerospork-design/ui_kits/settings_app/EventsTab.jsx
+++ b/.claude/skills/aerospork-design/ui_kits/settings_app/EventsTab.jsx
@@ -6,7 +6,7 @@ function CommandRows({ title, sf, footer, list, onChange }) {
   return (
     <FormSection header={<SectionLabel title={title} sf={sf} />} footer={footer}>
       {rows.map((c, i) => (c === null
-        ? <span key="empty" style={{ fontSize: 'var(--text-callout)', color: 'var(--label-tertiary)' }}>Nothing runs on this event.</span>
+        ? <span key="empty" style={{ fontSize: 'var(--text-callout)', color: 'var(--label-tertiary)' }}>Nothing here yet. Anything you add runs every time this event fires — exec-and-forget for a shell command, or an aerospork command directly.</span>
         : <div key={i} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
             <TextField mono value={c} placeholder="command" onChange={(v) => set(i, v)} style={{ flex: 1 }} />
             <Button variant="borderless" iconOnly title="Remove" onClick={() => onChange(list.filter((_, j) => j !== i))}>

--- a/.claude/skills/aerospork-design/ui_kits/settings_app/GapsTab.jsx
+++ b/.claude/skills/aerospork-design/ui_kits/settings_app/GapsTab.jsx
@@ -23,7 +23,7 @@ function GapsTab({ s, set }) {
           <NumberField title="Right" value={s.outerRight} onChange={(v) => set('outerRight', v)} />
         </FormSection>
       </div>
-      <SettingsFooter>Per-monitor gaps such as outer.top = [{ '{' } monitor.main = 16 { '}' }, 8] survive untouched until you change one of these — editing any gap rewrites the whole gaps section. Use Raw TOML for per-monitor rules.</SettingsFooter>
+      <SettingsFooter>Per-monitor gaps, such as a list of values under outer.top, survive untouched until you change one of these — editing any gap rewrites the whole gaps section. Use Raw TOML for per-monitor rules.</SettingsFooter>
     </div>
   );
 }

--- a/.claude/skills/aerospork-design/ui_kits/settings_app/KeysTab.jsx
+++ b/.claude/skills/aerospork-design/ui_kits/settings_app/KeysTab.jsx
@@ -33,7 +33,7 @@ function KeysTab({ bindings, setBindings }) {
           <span style={{ flex: 1 }} />
           <div className="filter">
             <Icon sf="magnifyingglass" size={12} style={{ color: 'var(--label-secondary)' }} />
-            <TextField variant="plain" placeholder="Filter" value={query} onChange={setQuery} width={150} />
+            <TextField variant="plain" placeholder="Filter" value={query} onChange={setQuery} width={150} /* capped: minWidth 70, idealWidth 150, maxWidth 150 in the Swift */ />
             {query && <button className="clear" onClick={() => setQuery('')}><Icon sf="xmark.circle.fill" size={12} /></button>}
           </div>
         </div>

--- a/Sources/AppBundle/ui/ConfigurationTabs/KeyBindingsTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/KeyBindingsTab.swift
@@ -80,9 +80,17 @@ struct KeyBindingsTab: View {
                 Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
                 TextField("Filter", text: $query)
                     .textFieldStyle(.plain)
-                    // Compressible. The mode picker beside it is `.fixedSize()`, so at the 780pt
-                    // minimum width a handful of modes pushed a hard-150pt filter box off the edge.
-                    .frame(minWidth: 70, idealWidth: 150)
+                    // Compressible, and capped. The mode picker beside it is `.fixedSize()`, so a
+                    // hard 150pt pushed the filter off the edge once a config had enough modes.
+                    //
+                    // `maxWidth` is not optional here: `minWidth:idealWidth:` alone leaves the upper
+                    // bound to the child, and a `.plain` TextField is greedy -- it ties with the
+                    // Spacer and swallows the slack, so at 880pt with the stock two modes the search
+                    // pill rendered 649pt wide instead of 150.
+                    //
+                    // This buys one more mode, not a fix: the segmented picker is still
+                    // `.fixedSize()`, so a config with nine modes still overflows 780pt.
+                    .frame(minWidth: 70, idealWidth: 150, maxWidth: 150)
                     .accessibilityLabel("Filter bindings")
                 if !query.isEmpty {
                     Button { query = "" } label: { Image(systemName: "xmark.circle.fill") }

--- a/Sources/AppBundle/ui/ConfigurationTabs/WindowRulesTab.swift
+++ b/Sources/AppBundle/ui/ConfigurationTabs/WindowRulesTab.swift
@@ -68,8 +68,8 @@ struct WindowRulesTab: View {
             // Monospace only for a real matcher, which is config text. "(any window)" is prose
             // describing an absence, and reading it as something pasteable is misleading.
             Text(summary(rule))
-                .font(summary(rule) == Self.anyWindow ? .body : .system(.body, design: .monospaced))
-                .foregroundStyle(summary(rule) == Self.anyWindow ? .secondary : .primary)
+                .font(hasNoMatchers(rule) ? .body : .system(.body, design: .monospaced))
+                .foregroundStyle(hasNoMatchers(rule) ? .secondary : .primary)
             // The UI has no control for `during-aerospork-startup`, but it round-trips it. Say so,
             // or a rule that only fires at startup looks identical to one that fires every time.
             if rule.duringStartup == true {
@@ -141,6 +141,14 @@ struct WindowRulesTab: View {
         viewModel.markAsModified()
         viewModel.scheduleAutoSave()
         self.selection = nil
+    }
+
+    /// Whether the row shows the placeholder rather than a matcher.
+    ///
+    /// Asked of the rule, not of the rendered string: an app id of literally `(any window)` is legal
+    /// free text, and comparing the summary would render a real matcher as prose.
+    private func hasNoMatchers(_ r: ConfigurationViewModel.WindowRuleRow) -> Bool {
+        r.appId.isEmpty && r.appNameRegex.isEmpty && r.windowTitleRegex.isEmpty && r.workspace.isEmpty
     }
 
     private func summary(_ r: ConfigurationViewModel.WindowRuleRow) -> String {

--- a/Sources/AppBundle/ui/SettingsChrome.swift
+++ b/Sources/AppBundle/ui/SettingsChrome.swift
@@ -31,16 +31,18 @@ struct NumberField: View {
     var body: some View {
         LabeledContent(title) {
             HStack(spacing: 6) {
+                // Both controls in this row are separately focusable, and `LabeledContent` names
+                // the row rather than either of them. An explicit `accessibilityLabel` on each,
+                // rather than relying on a hidden title surviving `labelsHidden()`.
                 TextField("", value: clamped, format: .number)
                     .textFieldStyle(.roundedBorder)
                     .multilineTextAlignment(.trailing)
                     .frame(width: 58)
                     .labelsHidden()
+                    .accessibilityLabel(title)
                 Text(unit)
                     .foregroundStyle(.secondary)
                     .font(.callout)
-                // Separately focusable, so it needs a name of its own: `LabeledContent` labels the
-                // row, not the second control inside it.
                 Stepper(title, value: clamped, in: range)
                     .labelsHidden()
                     .accessibilityLabel(title)

--- a/Sources/AppBundleTests/DesignKitParityTest.swift
+++ b/Sources/AppBundleTests/DesignKitParityTest.swift
@@ -1,0 +1,91 @@
+@testable import AppBundle
+import XCTest
+
+/// The design kit under `.claude/skills/aerospork-design/` is a recreation of the shipping SwiftUI,
+/// derived from it, and `CLAUDE.md` says it documents the shipping UI rather than proposing a
+/// different one. Nothing enforced that, and it drifted twice in three commits: once when the tab
+/// strings were corrected to sentence case, and again one commit after that resync when two
+/// empty-state strings were rewritten.
+///
+/// This pins the handful of user-visible strings that have actually drifted. It is deliberately a
+/// short explicit list rather than a general diff: the kit is a *recreation*, so most of it is
+/// allowed to differ, and a broad comparison would be noise that people learn to ignore.
+///
+/// When this fails, the fix is to update the kit — not to delete the entry.
+final class DesignKitParityTest: XCTestCase {
+    private var kitRoot: URL { projectRoot.appending(path: ".claude/skills/aerospork-design") }
+
+    private func read(_ relativePath: String) throws -> String {
+        try String(contentsOf: projectRoot.appending(path: relativePath), encoding: .utf8)
+    }
+
+    private func readKit(_ relativePath: String) throws -> String {
+        try String(contentsOf: kitRoot.appending(path: relativePath), encoding: .utf8)
+    }
+
+    /// A phrase the Swift shows the user, and the kit file that must show it too.
+    private struct Shared {
+        let phrase: String
+        let swiftFile: String
+        let kitFile: String
+    }
+
+    private let shared: [Shared] = [
+        .init(phrase: "Add rule",
+              swiftFile: "Sources/AppBundle/ui/ConfigurationTabs/WindowRulesTab.swift",
+              kitFile: "ui_kits/settings_app/RulesTab.jsx"),
+        .init(phrase: "Add assignment",
+              swiftFile: "Sources/AppBundle/ui/ConfigurationTabs/WorkspacesMonitorsTab.swift",
+              kitFile: "ui_kits/settings_app/MonitorsTab.jsx"),
+        .init(phrase: "Startup & behaviour",
+              swiftFile: "Sources/AppBundle/ui/ConfigurationTabs/GeneralSettingsTab.swift",
+              kitFile: "ui_kits/settings_app/GeneralTab.jsx"),
+        .init(phrase: "Pause tiling",
+              swiftFile: "Sources/AppBundle/ui/MenuBar.swift",
+              kitFile: "ui_kits/menu_bar/MenuBarKit.jsx"),
+        .init(phrase: "Non-main",
+              swiftFile: "Sources/AppBundle/ui/ConfigurationTabs/WorkspacesMonitorsTab.swift",
+              kitFile: "ui_kits/settings_app/MonitorsTab.jsx"),
+    ]
+
+    /// Each phrase must still be in the Swift. If it is not, the Swift changed and the entry below
+    /// is what tells you the kit needs the same change.
+    func testTheSharedPhrasesAreStillInTheSwift() throws {
+        for entry in shared {
+            let source = try read(entry.swiftFile)
+            XCTAssertTrue(
+                source.contains(entry.phrase),
+                """
+                "\(entry.phrase)" is no longer in \(entry.swiftFile). If it was renamed, rename it in
+                \(entry.kitFile) too and update this test — the kit is supposed to document what ships.
+                """,
+            )
+        }
+    }
+
+    func testTheKitShowsTheSamePhrases() throws {
+        for entry in shared {
+            let kit = try readKit(entry.kitFile)
+            XCTAssertTrue(
+                kit.contains(entry.phrase),
+                """
+                the design kit's \(entry.kitFile) does not show "\(entry.phrase)", which
+                \(entry.swiftFile) does. The kit is a recreation of the shipping UI, so it follows the
+                Swift rather than the other way round.
+                """,
+            )
+        }
+    }
+
+    /// The built bundle is generated from those sources and is what a mock actually loads, so a
+    /// stale copy there is the same defect one layer down.
+    func testTheBuiltBundleIsNotStale() throws {
+        let bundle = try readKit("_ds_bundle.js")
+        for phrase in ["Add rule", "Add assignment", "Pause tiling"] {
+            XCTAssertTrue(
+                bundle.contains(phrase),
+                "_ds_bundle.js is stale: it does not contain \"\(phrase)\". Rebuild it from the component sources.",
+            )
+        }
+    }
+}


### PR DESCRIPTION
A regression I shipped in #22, plus three follow-ups from the same adversarial review.

## The regression

Making the filter compressible shipped it **uncapped**:

```swift
.frame(minWidth: 70, idealWidth: 150)   // no maxWidth
```

`minWidth:idealWidth:` sets no upper bound — that falls through to the child — and a `.plain`
TextField is greedy, so it ties with the `Spacer(minLength: 16)` beside it and takes all the slack.

Measured against a faithful reproduction of the toolbar:

| modes | window | filter pill before → after the regression |
|---|---|---|
| 2 (stock config) | 780 | 184 → **549** |
| 2 | 880 (ideal) | 184 → **649** |
| 2 | 1400 | 184 → **1169** |

Every config at every window size ≥ 780. `maxWidth: 150` restores the previous layout exactly where
it fit, and keeps the new compression in the overflow case it was written for.

**The comment also overclaimed.** Capping buys one more mode; it does not fix the overflow. The
segmented picker is still `.fixedSize()`, so nine modes still clip at 780pt. The comment says so now.

## Follow-ups

- **The number field was the unnamed one.** I gave the stepper an accessibility label and wrote the
  justification above it, while the control the user actually types into kept an empty label. Both
  are labelled now.
- **`(any window)` was matched by string.** The rules list picked its font by comparing the rendered
  summary, so a rule whose app id is literally `(any window)` — legal free text — rendered as prose.
  It asks the rule instead.

## The kit drifted again

One commit after #19 resynced it. `DesignKitParityTest` now pins the phrases that have actually
drifted, and it immediately caught something #19 missed: that resync updated the JSX sources and left
**seven stale strings in the built bundle**, which is what a mock actually loads.

The list is deliberately short and explicit rather than a general diff — the kit is a recreation, so
most of it is allowed to differ, and a broad comparison would be noise people learn to ignore.

## Verified clean by the same review

`draw(in:)` renders pixel-identically to `draw(at:)` and truncates with a real ellipsis (bitmaps
diffed); the placeholder font swap causes no jitter (both 16.0pt line height); control titles under
`.labelsHidden()` cost no layout; and no other call site renders user-controlled text as markdown.

`./run-tests.sh` green.