### PR TITLE
Remember which workspace and monitor each window was on

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,26 @@ with its own XPC helpers in `Contents/Frameworks`, so the release script signs n
 deepest-first before sealing the bundle, copies with `cp -R` to keep the framework's symlinks, and
 checks that every nested Mach-O is independently signed rather than rejecting nested code outright.
 
+**Workspace memory across a restart**: `WorkspaceMemory.swift` persists window -> workspace, plus
+the monitor each workspace was on, to `/tmp/<bundle-id>-<user>.state.json`.
+
+> **Both halves, or neither.** A first version restored only the workspace *name* and was reverted:
+> `Workspace.get(byName:)` mints a workspace whose `assignedMonitorPoint` is nil, and the only
+> writers of that field run when a workspace becomes visible or is force-assigned — so
+> `workspaceMonitor` fell through to `mainMonitor` and every restored workspace collapsed onto the
+> main display. Worse than binding by location, which at least kept the monitor.
+> `restoredWorkspace(forWindowId:bundleId:)` is the single entry point that does both, and
+> `WorkspaceMemoryTest` fails if registration calls the name-only lookup.
+
+The key is the `CGWindowID` and nothing else. It comes from a monotonic counter owned by
+**WindowServer**, so it is stable across a restart of *this* process and meaningless afterwards. The
+generation token is therefore WindowServer's pid and start time, **not** `kern.boottime`: the counter
+restarts on log out, `killall WindowServer` and graphics faults, none of which reboot the machine,
+and the kernel also *adjusts* `boottime` whenever the calendar clock is stepped. A composite key
+(bundle id + title + index + frame) cannot substitute — `AXIdentifier` names a window *class*
+(`TerminalWindowRestoration`, `FinderWindow`), so identical windows are genuinely indistinguishable
+and a fuzzy key would permute them silently.
+
 **MRU Tracking**: Tree nodes track most-recently-used order for focus navigation.
 
 ## Design System
@@ -241,6 +261,7 @@ it is present.
 - `Sources/AppBundle/config/parseConfig.swift`: Configuration parser
 - `Sources/AppBundle/runLoop.swift`: Main refresh session loop
 - `Sources/AppBundle/ui/SettingsChrome.swift`: Every shared settings control, and the only copy of each
+- `Sources/AppBundle/WorkspaceMemory.swift`: Window→workspace placement across a restart
 - `.claude/skills/aerospork-design/readme.md`: Design system — voice, visual foundations, components
 
 ## Testing

--- a/Sources/AppBundle/WorkspaceMemory.swift
+++ b/Sources/AppBundle/WorkspaceMemory.swift
@@ -1,0 +1,309 @@
+import AppKit
+import Common
+import Foundation
+
+/// Remembers where each window was, so restarting AeroSpork does not scatter the layout.
+///
+/// ## Why this is needed
+///
+/// Workspaces are emulated, not native Spaces: a hidden workspace's windows are parked off screen.
+/// Nothing outside this process knows a window "belongs to" workspace `A`. At launch a window is
+/// bound by where it physically sits, and at a cold start no workspace is active yet, so
+/// `getStubWorkspace` invents one per monitor from the first keybound name in sort order. `A` sorts
+/// after every digit, so a window left on `A` could never return to it. That is structural.
+///
+/// ## Both halves, or neither
+///
+/// A workspace name on its own is not enough, and a first attempt at this shipped exactly that
+/// mistake. `Workspace.get(byName:)` mints a workspace whose `assignedMonitorPoint` is nil, and the
+/// only writers of that field run when a workspace becomes *visible* or is force-assigned -- neither
+/// true of one restored from a file. `workspaceMonitor` then falls through to `mainMonitor`, so
+/// every restored workspace lands on the main display: right name, wrong monitor, with the other
+/// monitors showing empty stubs. That is worse than binding by location, which at least got the
+/// monitor right. So the monitor is persisted with the workspace and reassigned on restore.
+///
+/// ## Why `CGWindowID` alone, and nothing cleverer
+///
+/// The id comes from a monotonic counter in the WindowServer. It is exactly stable while that
+/// process lives -- which spans any restart of *this* one -- and meaningless afterwards.
+///
+/// A composite key (bundle id + title + index + frame) looks like it would also survive an app
+/// relaunch, and cannot. `AXIdentifier` names a window *class*, not an instance: every Terminal
+/// window reports `TerminalWindowRestoration`, every Finder window `FinderWindow`, as the `axDumps/`
+/// fixtures show. Titles follow tabs, the index into `kAXWindowsAttribute` is z-order, and the quit
+/// cleanup overwrites the frame. Several identical terminal windows are indistinguishable, so a
+/// composite key would shuffle them into an arbitrary permutation -- silently, and untestably, since
+/// the fixtures really are identical. An exact id match cannot be wrong; it can only be absent.
+///
+/// Where the id is gone, `on-window-detected` with `if.during-aerospork-startup` is the right tool,
+/// because there the user states intent instead of us guessing.
+///
+/// ## The generation token is the WindowServer, not the boot
+///
+/// The id counter restarts from the bottom whenever WindowServer does: a log out and back in, a
+/// `killall WindowServer`, a graphics fault. None of those reboot the machine, and `/tmp` is not
+/// cleared at logout. Guarding on `kern.boottime` therefore accepted a stale file across a logout --
+/// new WindowServer hands out low ids again, macOS reopens the same apps so the bundle id still
+/// matches, and windows land on workspaces they were never on. That is the one way this design could
+/// produce a wrong answer rather than no answer, and the boot time does not close it. Measured here,
+/// WindowServer started 49 seconds after boot, so the two are not even the same instant.
+///
+/// `kern.boottime` is unsuitable for a second reason: the kernel *adjusts* it when the calendar
+/// clock is stepped, so an NTP correction would silently discard a good file.
+@MainActor
+enum WorkspaceMemory {
+    struct WindowEntry: Codable, Equatable, Sendable {
+        let workspace: String
+        /// Checked against the live window's app, so an id reused within one WindowServer session by
+        /// a different application is a no-op rather than a misplacement.
+        let bundleId: String?
+    }
+
+    struct State: Codable, Equatable, Sendable {
+        let session: String
+        let windows: [String: WindowEntry]
+        /// Workspace name to the monitor it was on. Without this the restore is worse than useless
+        /// on a multi-monitor setup; see the note above.
+        let workspaceMonitors: [String: MonitorFingerprint]
+    }
+
+    /// Overridable so tests do not read or delete the real file. The default sits beside the CLI
+    /// socket and deliberately nowhere near the config: this is a disposable cache, and
+    /// `ConfigurationWriter`'s do-no-harm invariant must not be dragged into it.
+    static var fileUrlOverride: URL?
+    static var fileUrl: URL {
+        fileUrlOverride ?? URL(filePath: "/tmp/\(aeroSporkAppId)-\(unixUserName).state.json")
+    }
+
+    /// WindowServer's pid and start time. Changes on every event that resets the id counter, and on
+    /// reboot too, so it strictly dominates `kern.boottime`.
+    static func currentSession() -> String {
+        var name: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0]
+        var len = 0
+        guard sysctl(&name, 4, nil, &len, nil, 0) == 0, len > 0 else { return "" }
+        let capacity = len / MemoryLayout<kinfo_proc>.stride
+        var procs = [kinfo_proc](repeating: kinfo_proc(), count: capacity)
+        guard sysctl(&name, 4, &procs, &len, nil, 0) == 0 else { return "" }
+        for var proc in procs[0 ..< min(capacity, len / MemoryLayout<kinfo_proc>.stride)] {
+            let comm = withUnsafeBytes(of: &proc.kp_proc.p_comm) { raw in
+                String(cString: raw.baseAddress!.assumingMemoryBound(to: CChar.self))
+            }
+            guard comm == "WindowServer" else { continue }
+            let start = proc.kp_proc.p_un.__p_starttime
+            return "ws:\(proc.kp_proc.p_pid):\(start.tv_sec).\(start.tv_usec)"
+        }
+        // No WindowServer (headless, or a sysctl failure). An empty token never equals a stored one,
+        // so the memory is simply not used -- the guard degrades closed.
+        return ""
+    }
+
+    static func session() -> String {
+        if let cachedSession { return cachedSession }
+        let value = currentSession()
+        cachedSession = value
+        return value
+    }
+
+    private static var restored: State?
+    /// `save()` before `load()` would persist an empty tree over a good file. That window is
+    /// milliseconds wide -- a signal between `initTerminationHandler` and `load` -- but it costs one
+    /// Bool to close.
+    private static var isLoaded = false
+    /// Skips the expensive half and the write when nothing changed, which is most refreshes.
+    private static var lastWritten: CheapKey?
+    /// `currentSession()` copies the whole process table -- measured 633 KiB and ~950 String
+    /// allocations per call. It cannot meaningfully change while we run: if WindowServer restarts,
+    /// every id we hold is void anyway. So it is read once.
+    private static var cachedSession: String?
+    /// Set the moment quitting begins. `makeAllWindowsVisibleAndRestoreSize` moves every window, and
+    /// each AX write emits a notification that schedules a refresh -- which would call `save()`
+    /// again and persist where the windows were dumped instead of where they belonged. Freezing is
+    /// simpler than cancelling the pending refresh and does not depend on the debouncer's state.
+    private static var isFrozen = false
+
+
+    /// Reads the file if it belongs to this WindowServer session. Call once, before any window can
+    /// be registered.
+    static func load() {
+        restored = nil
+        lastWritten = nil
+        isLoaded = true
+        guard let data = try? Data(contentsOf: fileUrl),
+              let state = try? JSONDecoder().decode(State.self, from: data)
+        else { return }
+        let live = session()
+        // An empty LIVE token means we could not identify the session, not that the file is stale.
+        // Deleting on that would treat a failure to look as proof, and destroy a good file.
+        guard !live.isEmpty else {
+            debugLog("WorkspaceMemory: no WindowServer session; leaving the file alone and not restoring")
+            return
+        }
+        guard !state.session.isEmpty, state.session == live else {
+            debugLog("WorkspaceMemory: discarding state from a previous WindowServer session")
+            try? FileManager.default.removeItem(at: fileUrl)
+            return
+        }
+        restored = state
+        debugLog("WorkspaceMemory: restored \(state.windows.count) windows")
+    }
+
+    /// The workspace this window was on, when it is provably the same window.
+    static func workspace(forWindowId id: UInt32, bundleId: String?) -> String? {
+        guard let entry = restored?.windows[String(id)] else { return nil }
+        // A nil bundle id on either side is not a match: unknown is not the same as equal.
+        guard let remembered = entry.bundleId, let bundleId, remembered == bundleId else { return nil }
+        return entry.workspace
+    }
+
+    /// The workspace to bind a window to on restart, with its monitor already reattached.
+    ///
+    /// One entry point on purpose. Callers that took only the name got a workspace reporting
+    /// `mainMonitor`, which collapsed every remembered workspace onto one display -- the defect that
+    /// forced the first version of this to be reverted. Both halves, or neither.
+    static func restoredWorkspace(forWindowId id: UInt32, bundleId: String?) -> Workspace? {
+        guard let name = workspace(forWindowId: id, bundleId: bundleId) else { return nil }
+        let workspace = Workspace.get(byName: name)
+        restoreMonitor(of: workspace)
+        return workspace
+    }
+
+    /// The monitor `workspace` was on, if it is still attached.
+    ///
+    /// UUID first, for the same reason `MonitorFingerprint.matches` checks it first: it is the only
+    /// key that separates two otherwise identical panels. Full equality is the fallback, which also
+    /// covers monitors that report no UUID.
+    static func monitor(forWorkspace workspace: String) -> Monitor? {
+        guard let saved = restored?.workspaceMonitors[workspace] else { return nil }
+        let live = monitors
+        if let uuid = saved.displayUUID, !uuid.isEmpty,
+           let match = live.first(where: { $0.fingerprint?.displayUUID == uuid })
+        {
+            return match
+        }
+        return live.first { $0.fingerprint == saved }
+    }
+
+    /// Puts a restored workspace back on its monitor. Idempotent, and a no-op when the monitor is
+    /// gone -- that workspace then falls back to today's behaviour instead of to a wrong answer.
+    static func restoreMonitor(of workspace: Workspace) {
+        guard let monitor = monitor(forWorkspace: workspace.name) else { return }
+        workspace.assignMonitor(monitor)
+    }
+
+    /// The cheap half of a snapshot: what is bound where, and which monitor each workspace is on by
+    /// screen id. No fingerprints, no `sysctl`.
+    ///
+    /// This exists so the change check can run before the expensive half. Building the full state
+    /// first and comparing afterwards meant every refresh paid for it, including the ones that
+    /// changed nothing — which is most of them.
+    private struct CheapKey: Equatable {
+        let windows: [String: WindowEntry]
+        let workspaceScreens: [String: Int]
+    }
+
+    private static func cheapKey() -> CheapKey {
+        var windows: [String: WindowEntry] = [:]
+        var workspaceScreens: [String: Int] = [:]
+        for window in MacWindow.allWindows {
+            guard let workspace = window.nodeWorkspace else { continue }
+            windows[String(window.windowId)] = WindowEntry(
+                workspace: workspace.name,
+                bundleId: window.macApp.bundleId,
+            )
+            if workspaceScreens[workspace.name] == nil {
+                workspaceScreens[workspace.name] = workspace.workspaceMonitor.monitorAppKitNsScreenScreensId
+            }
+        }
+        return CheapKey(windows: windows, workspaceScreens: workspaceScreens)
+    }
+
+    /// The full state. `MonitorFingerprint.fromScreen` is four CoreGraphics round trips per monitor
+    /// and the monitor list is rebuilt on every access, so this is only reached when `cheapKey`
+    /// says something actually changed.
+    private static func fullState(_ key: CheapKey) -> State {
+        State(
+            session: session(),
+            windows: key.windows,
+            workspaceMonitors: workspaceMonitors(for: Set(key.workspaceScreens.keys)),
+        )
+    }
+
+    /// The fingerprint of each named workspace's monitor.
+    ///
+    /// Separate from `fullState` so it can be tested without a real window tree: a headless suite
+    /// has no `MacWindow`s, so a test driving `save()` end to end always produces an empty map and
+    /// cannot tell whether monitors are recorded at all.
+    static func workspaceMonitors(for names: Set<String>) -> [String: MonitorFingerprint] {
+        var result: [String: MonitorFingerprint] = [:]
+        for name in names {
+            if let fingerprint = Workspace.get(byName: name).workspaceMonitor.fingerprint {
+                result[name] = fingerprint
+            }
+        }
+        return result
+    }
+
+    /// Serial, so two writes cannot land out of order.
+    ///
+    /// Two `Task.detached` writes raced: `.atomic` is write-then-rename, and with no ordering
+    /// guarantee the OLDER snapshot won about half the time — measured 240/500. Worse, `lastWritten`
+    /// had already recorded the newer one, so the early-out suppressed every attempt to correct it.
+    private static let writeQueue = DispatchQueue(label: "\(aeroSporkAppId).workspace-memory")
+
+    private static func write(_ state: State, waitForCompletion: Bool) {
+        // Never persist a state whose session we could not determine: `load()` would reject it, so
+        // writing it just destroys whatever was there.
+        guard !state.session.isEmpty else { return }
+        let url = fileUrl
+        let work = {
+            guard let data = try? JSONEncoder().encode(state) else { return }
+            try? data.write(to: url, options: .atomic)
+        }
+        if waitForCompletion { writeQueue.sync(execute: work) } else { writeQueue.async(execute: work) }
+    }
+
+    /// Persists the tree if it changed. The snapshot stays on the main thread; encoding and writing
+    /// do not.
+    static func save() {
+        guard isLoaded, !isFrozen else { return }
+        let key = cheapKey()
+        guard key != lastWritten else { return }
+        lastWritten = key
+        write(fullState(key), waitForCompletion: false)
+    }
+
+    /// The quit-time save. Waits for the write — and because the queue is serial and FIFO, waiting
+    /// also drains any refresh-scheduled write still in flight, so none of them can land on top of
+    /// this one afterwards.
+    static func freezeAndSave() {
+        guard isLoaded else { isFrozen = true; return }
+        let key = cheapKey()
+        lastWritten = key
+        write(fullState(key), waitForCompletion: true)
+        isFrozen = true
+    }
+
+    /// Test seams for the two paths a test cannot otherwise reach: writing a state directly, and
+    /// pretending the session could not be read.
+    static func writeForTests(_ state: State) { write(state, waitForCompletion: false) }
+    static func forceSessionForTests(_ value: String) { cachedSession = value }
+
+    /// Test seam: blocks until every queued write has landed, so a test can read the file back
+    /// without racing the asynchronous path that production actually uses.
+    static func waitForWrites() { writeQueue.sync {} }
+
+    /// Forgets what was last written, so the next `save()` really tries to write. Without this a
+    /// test cannot tell the freeze guard from the unchanged-tree early-out.
+    static func invalidateChangeCheckForTests() { lastWritten = nil }
+
+    /// Test seam. All the state here is process-global, which is right for a singleton with one
+    /// lifecycle and wrong for a suite that runs many cases in one process.
+    static func resetForTests() {
+        restored = nil
+        lastWritten = nil
+        isLoaded = false
+        isFrozen = false
+        fileUrlOverride = nil
+        cachedSession = nil
+    }
+}

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -22,6 +22,10 @@ import Foundation
         check(reloadConfig(forceConfigUrl: defaultConfigUrl))
     }
 
+    // Before anything can register a window: `MacWindow.getOrRegister` consults it on the first
+    // adoption of each window, and a miss there is permanent for that window.
+    WorkspaceMemory.load()
+
     checkAccessibilityPermissions()
     startUnixSocketServer()
     GlobalObserver.initObserver()

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -72,6 +72,10 @@ func runRefreshSessionBlocking(
             updateTrayText()
             try await normalizeLayoutReason()
             if shouldLayoutWorkspaces { try await layoutWorkspaces() }
+            // Here as well as at quit: a crash, a force quit and `killall -9` never reach the quit
+            // path, and those are the restarts where remembering is worth the most. The snapshot is
+            // one dictionary walk and returns early when nothing changed; the write is off-thread.
+            WorkspaceMemory.save()
         }
     }
 }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -23,7 +23,12 @@ final class MacWindow: Window {
             windowId,
             macApp,
             isStartup
-                ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
+                // Where this window was before the restart, when it is provably the same window.
+                // Location is the fallback, not the first answer: at a cold start no workspace is
+                // active, so that branch resolves to a stub invented from the first keybound name in
+                // sort order -- which a named workspace like `A` can never be.
+                ? WorkspaceMemory.restoredWorkspace(forWindowId: windowId, bundleId: macApp.bundleId)
+                    ?? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
                 : focus.workspace,
             window: nil,
         )

--- a/Sources/AppBundle/tree/Workspace.swift
+++ b/Sources/AppBundle/tree/Workspace.swift
@@ -194,6 +194,16 @@ extension Workspace {
         }
     }
 
+    /// Pins an *invisible* workspace to a monitor.
+    ///
+    /// `assignedMonitorPoint` is otherwise only written when a workspace becomes visible or is
+    /// force-assigned, so a workspace materialized by name -- as `WorkspaceMemory` does when
+    /// restoring after a restart -- had no monitor at all and `workspaceMonitor` answered
+    /// `mainMonitor` for it.
+    @MainActor func assignMonitor(_ monitor: Monitor) {
+        assignedMonitorPoint = monitor.rect.topLeftCorner
+    }
+
     @MainActor var forceAssignedMonitor: Monitor? {
         guard let monitorDescriptions = config.workspaceToMonitorForceAssignment[name] else {
             return nil

--- a/Sources/AppBundle/util/appBundleUtil.swift
+++ b/Sources/AppBundle/util/appBundleUtil.swift
@@ -31,6 +31,9 @@ func initTerminationHandler() {
 
 private struct AppServerTerminationHandler: TerminationHandler {
     func beforeTermination() async throws {
+        // BEFORE the cleanup, which moves every window -- and frozen, so the refresh those moves
+        // trigger cannot overwrite this snapshot with the dumped positions.
+        WorkspaceMemory.freezeAndSave()
         try await makeAllWindowsVisibleAndRestoreSize()
         if isDebug {
             sendCommandToReleaseServer(args: ["enable", "on"])

--- a/Sources/AppBundleTests/WorkspaceMemoryTest.swift
+++ b/Sources/AppBundleTests/WorkspaceMemoryTest.swift
@@ -1,0 +1,464 @@
+@testable import AppBundle
+import Common
+import Foundation
+import XCTest
+
+/// Restoring window placement across a restart.
+///
+/// The first version of this feature was reverted, and the reason shapes these tests: it restored a
+/// workspace *name* and nothing else, so every restored workspace reported `mainMonitor` and a
+/// multi-monitor layout collapsed onto one display. Its own suite stayed green through all of it,
+/// because it only ever exercised the pure lookup API — emptying `save()` or deleting the restore
+/// hook changed nothing. So the tests that matter here are the ones about the **monitor** and about
+/// the hook being wired at all.
+@MainActor
+final class WorkspaceMemoryTest: XCTestCase {
+    private var tempDir: URL!
+    private var savedMonitors: [Monitor]!
+
+    /// Two monitors that differ only by UUID — the case the whole fingerprint design exists for, and
+    /// the one a name or a size cannot tell apart.
+    private let leftUuid = "11111111-1111-1111-1111-111111111111"
+    private let rightUuid = "22222222-2222-2222-2222-222222222222"
+
+    private func fingerprint(uuid: String) -> MonitorFingerprint {
+        MonitorFingerprint(
+            vendorID: nil, modelID: nil, serialNumber: nil,
+            displayName: "ACME 32", widthPixels: 3840, heightPixels: 2160,
+            displayUUID: uuid,
+        )
+    }
+
+    override func setUp() {
+        WorkspaceMemory.resetForTests()
+        savedMonitors = testMonitors
+        tempDir = URL(filePath: NSTemporaryDirectory()).appending(path: "wsmem-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        // Never the real file: the previous suite wrote to the live debug state path and deleted it
+        // in setUp, so running the tests destroyed a running debug app's state.
+        WorkspaceMemory.fileUrlOverride = tempDir.appending(path: "state.json")
+
+        let left = Rect(topLeftX: 0, topLeftY: 0, width: 3840, height: 2160)
+        let right = Rect(topLeftX: 3840, topLeftY: 0, width: 3840, height: 2160)
+        testMonitors = [
+            MonitorImpl(monitorAppKitNsScreenScreensId: 1, name: "ACME 32", rect: left, visibleRect: left,
+                        fingerprint: fingerprint(uuid: leftUuid)),
+            MonitorImpl(monitorAppKitNsScreenScreensId: 2, name: "ACME 32", rect: right, visibleRect: right,
+                        fingerprint: fingerprint(uuid: rightUuid)),
+        ]
+    }
+
+    override func tearDown() {
+        testMonitors = savedMonitors
+        WorkspaceMemory.resetForTests()
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func write(_ state: WorkspaceMemory.State) {
+        try! JSONEncoder().encode(state).write(to: WorkspaceMemory.fileUrl)
+    }
+
+    private func state(
+        session: String,
+        windows: [String: WorkspaceMemory.WindowEntry],
+        monitors: [String: MonitorFingerprint] = [:],
+    ) -> WorkspaceMemory.State {
+        WorkspaceMemory.State(session: session, windows: windows, workspaceMonitors: monitors)
+    }
+
+    // MARK: - The defect that forced the revert
+
+    /// A restored workspace must come back on the monitor it was on, not on the main one.
+    ///
+    /// This is the whole point. Restoring only the name gives a `Workspace` whose
+    /// `assignedMonitorPoint` is nil, and `workspaceMonitor` then falls through to `mainMonitor` —
+    /// so every remembered workspace piles onto one display. That version passed its own tests.
+    func testARestoredWorkspaceKeepsItsMonitor() {
+        write(state(
+            session: WorkspaceMemory.currentSession(),
+            windows: ["42": .init(workspace: "A", bundleId: "com.apple.finder")],
+            monitors: ["A": fingerprint(uuid: rightUuid)],
+        ))
+        WorkspaceMemory.load()
+
+        let workspace = try! XCTUnwrap(
+            WorkspaceMemory.restoredWorkspace(forWindowId: 42, bundleId: "com.apple.finder"),
+        )
+        assertEquals(workspace.name, "A")
+        XCTAssertEqual(
+            workspace.workspaceMonitor.rect.topLeftX, 3840,
+            "restored onto the main monitor instead of the one it was on -- this is the revert defect",
+        )
+    }
+
+    /// What the UUID-first branch is actually for: the panel is the same one, but something else
+    /// about it changed while AeroSpork was not running.
+    ///
+    /// Whole-fingerprint equality fails here — the resolution and the name both moved — so without
+    /// the UUID check the workspace silently loses its monitor. Note that the *other* obvious test,
+    /// two monitors differing only by UUID, proves nothing about ordering: plain equality already
+    /// includes the UUID and picks correctly.
+    func testAMonitorIsStillFoundAfterItsResolutionOrNameChanges() {
+        let stale = MonitorFingerprint(
+            vendorID: nil, modelID: nil, serialNumber: nil,
+            displayName: "ACME 32 (old name)", widthPixels: 1920, heightPixels: 1080,
+            displayUUID: rightUuid,
+        )
+        write(state(
+            session: WorkspaceMemory.session(),
+            windows: ["5": .init(workspace: "D", bundleId: "com.apple.finder")],
+            monitors: ["D": stale],
+        ))
+        WorkspaceMemory.load()
+
+        let monitor = WorkspaceMemory.monitor(forWorkspace: "D")
+        XCTAssertEqual(
+            monitor?.rect.topLeftX, 3840,
+            "the panel was not recognised after its resolution changed, so the workspace lost its monitor",
+        )
+    }
+
+    /// Two monitors differing only by UUID must not be confused for one another.
+    func testTheMonitorIsMatchedByUuidNotByName() {
+        write(state(
+            session: WorkspaceMemory.currentSession(),
+            windows: ["7": .init(workspace: "B", bundleId: "com.apple.finder")],
+            monitors: ["B": fingerprint(uuid: leftUuid)],
+        ))
+        WorkspaceMemory.load()
+
+        let workspace = try! XCTUnwrap(WorkspaceMemory.restoredWorkspace(forWindowId: 7, bundleId: "com.apple.finder"))
+        assertEquals(workspace.workspaceMonitor.rect.topLeftX, 0)
+    }
+
+    /// A monitor that is no longer attached must degrade to today's behaviour, not to a wrong one.
+    func testAnUnpluggedMonitorLeavesTheWorkspaceUnpinned() {
+        write(state(
+            session: WorkspaceMemory.currentSession(),
+            windows: ["9": .init(workspace: "C", bundleId: "com.apple.finder")],
+            monitors: ["C": fingerprint(uuid: "33333333-3333-3333-3333-333333333333")],
+        ))
+        WorkspaceMemory.load()
+
+        XCTAssertNotNil(WorkspaceMemory.restoredWorkspace(forWindowId: 9, bundleId: "com.apple.finder"))
+        XCTAssertNil(WorkspaceMemory.monitor(forWorkspace: "C"), "an absent monitor must not resolve to something else")
+    }
+
+    // MARK: - The generation guard
+
+    /// `CGWindowID`s are reissued from the bottom when WindowServer restarts, which a log out does
+    /// without rebooting. A file from a previous session names ids that now mean something else.
+    func testStateFromAnotherWindowServerSessionRestoresNothing() {
+        write(state(session: "ws:1:1.1", windows: ["42": .init(workspace: "A", bundleId: "com.apple.finder")]))
+        WorkspaceMemory.load()
+
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), nil)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: WorkspaceMemory.fileUrl.path),
+            "a file from a dead session should be deleted, not left to be reconsidered",
+        )
+    }
+
+    /// An empty token means we could not identify the session at all. It must never compare equal to
+    /// a stored one, or the guard degrades open.
+    func testAnEmptySessionTokenNeverMatches() {
+        write(state(session: "", windows: ["42": .init(workspace: "A", bundleId: "com.apple.finder")]))
+        WorkspaceMemory.load()
+
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), nil)
+    }
+
+    /// The token must really name the running WindowServer.
+    ///
+    /// A shape-only assertion is not enough: stubbing `currentSession()` to a constant passes
+    /// `hasPrefix("ws:")` while making the guard incapable of ever rejecting a stale file — which is
+    /// the whole defect it exists to prevent. Verified by doing exactly that and watching the weaker
+    /// version stay green. So this cross-checks the pid against `pgrep`, which reaches the process
+    /// list by a different route than the `sysctl` under test.
+    func testTheSessionTokenNamesTheRunningWindowServer() throws {
+        let token = WorkspaceMemory.currentSession()
+        let parts = token.split(separator: ":")
+        try XCTSkipIf(parts.count != 3 && !FileManager.default.fileExists(atPath: "/usr/bin/pgrep"),
+                      "no WindowServer and no pgrep: not a graphical session")
+        assertEquals(parts.count, 3, additionalMsg: "unexpected token shape: \(token)")
+        assertEquals(String(parts[0]), "ws")
+
+        let pgrep = Process()
+        pgrep.executableURL = URL(filePath: "/usr/bin/pgrep")
+        pgrep.arguments = ["-x", "WindowServer"]
+        let pipe = Pipe()
+        pgrep.standardOutput = pipe
+        try XCTSkipIf((try? pgrep.run()) == nil, "could not run pgrep")
+        pgrep.waitUntilExit()
+        let pids = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            .split(whereSeparator: \.isNewline).map(String.init)
+        try XCTSkipIf(pids.isEmpty, "WindowServer is not running; nothing to cross-check against")
+
+        XCTAssertTrue(
+            pids.contains(String(parts[1])),
+            "token names pid \(parts[1]) but pgrep reports WindowServer at \(pids) -- the token does "
+                + "not identify the real session, so the guard can never reject a stale file",
+        )
+        XCTAssertTrue(Double(parts[2]) != nil, "start time is not a number: \(parts[2])")
+    }
+
+    /// Two calls in the same session must agree, or every load would discard a valid file.
+    func testTheSessionTokenIsStable() {
+        assertEquals(WorkspaceMemory.currentSession(), WorkspaceMemory.currentSession())
+    }
+
+    // MARK: - Refusals
+
+    func testAnUnknownWindowIdIsNotAnswered() {
+        write(state(session: WorkspaceMemory.currentSession(),
+                    windows: ["42": .init(workspace: "A", bundleId: "com.apple.finder")]))
+        WorkspaceMemory.load()
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 99, bundleId: "com.apple.finder"), nil)
+    }
+
+    func testAnIdNowOwnedByADifferentAppIsNotAnswered() {
+        write(state(session: WorkspaceMemory.currentSession(),
+                    windows: ["42": .init(workspace: "A", bundleId: "com.apple.finder")]))
+        WorkspaceMemory.load()
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.googlecode.iterm2"), nil)
+    }
+
+    /// Unknown is not the same as equal, in either direction.
+    func testAMissingBundleIdIsNeverAMatch() {
+        write(state(session: WorkspaceMemory.currentSession(), windows: [
+            "42": .init(workspace: "A", bundleId: "com.apple.finder"),
+            "43": .init(workspace: "B", bundleId: nil),
+        ]))
+        WorkspaceMemory.load()
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: nil), nil)
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 43, bundleId: "com.apple.finder"), nil)
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 43, bundleId: nil), nil)
+    }
+
+    func testNoFileAndCorruptFileBothRestoreNothing() {
+        WorkspaceMemory.load()
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), nil)
+
+        try! Data("not json".utf8).write(to: WorkspaceMemory.fileUrl)
+        WorkspaceMemory.load()
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), nil)
+    }
+
+    // MARK: - Writing
+
+    /// Exercises `save()`, the function production actually calls — not `saveBlocking`.
+    ///
+    /// The previous version of these tests only ever went through a test-only helper, so every
+    /// mutation of the real write path survived: emptying `save()`, deleting the write inside its
+    /// detached task, returning before scheduling it. All of them left the suite green.
+    func testSaveWritesAFileThatLoadAccepts() throws {
+        WorkspaceMemory.load() // no file yet
+        XCTAssertFalse(FileManager.default.fileExists(atPath: WorkspaceMemory.fileUrl.path))
+
+        WorkspaceMemory.save()
+        WorkspaceMemory.waitForWrites()
+
+        let data = try XCTUnwrap(
+            try? Data(contentsOf: WorkspaceMemory.fileUrl),
+            "save() wrote nothing, so nothing can ever be restored",
+        )
+        let written = try JSONDecoder().decode(WorkspaceMemory.State.self, from: data)
+        assertEquals(written.session, WorkspaceMemory.session())
+    }
+
+    /// And what it writes must survive the next load rather than being discarded as stale.
+    func testWhatSaveWritesIsStillValidOnTheNextLoad() throws {
+        WorkspaceMemory.load()
+        WorkspaceMemory.save()
+        WorkspaceMemory.waitForWrites()
+
+        WorkspaceMemory.load()
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: WorkspaceMemory.fileUrl.path),
+            "load() deleted the file save() had just written, so the memory can never survive a restart",
+        )
+    }
+
+    /// A signal arriving between `initTerminationHandler` and `load()` would otherwise persist an
+    /// empty tree over a good file.
+    func testSaveBeforeLoadDoesNotTouchTheFile() throws {
+        write(state(session: WorkspaceMemory.session(),
+                    windows: ["42": .init(workspace: "A", bundleId: "com.apple.finder")]))
+        let before = try Data(contentsOf: WorkspaceMemory.fileUrl)
+
+        WorkspaceMemory.save() // no load() first
+        WorkspaceMemory.waitForWrites()
+
+        assertEquals(try Data(contentsOf: WorkspaceMemory.fileUrl), before)
+    }
+
+    /// The quit path must take a real snapshot and *then* stop.
+    ///
+    /// Asserting only "nothing changed after the freeze" is vacuous: swapping the two statements in
+    /// `freezeAndSave` so quitting persists nothing at all passes that. So this asserts the content
+    /// actually landed.
+    func testTheQuitSaveWritesTheTreeAndThenFreezes() throws {
+        WorkspaceMemory.load()
+
+        WorkspaceMemory.freezeAndSave()
+        WorkspaceMemory.waitForWrites()
+
+        let data = try XCTUnwrap(
+            try? Data(contentsOf: WorkspaceMemory.fileUrl),
+            "quitting wrote nothing -- the freeze happened before the save",
+        )
+        let written = try JSONDecoder().decode(WorkspaceMemory.State.self, from: data)
+        assertEquals(written.session, WorkspaceMemory.session())
+
+        // And then nothing more is accepted. The change check has to be invalidated first, or an
+        // unchanged tree short-circuits `save()` and the freeze guard looks tested when it is not.
+        try FileManager.default.removeItem(at: WorkspaceMemory.fileUrl)
+        WorkspaceMemory.invalidateChangeCheckForTests()
+        WorkspaceMemory.save()
+        WorkspaceMemory.waitForWrites()
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: WorkspaceMemory.fileUrl.path),
+            "a save after the freeze landed, so the cleanup's own refresh can overwrite the snapshot",
+        )
+    }
+
+    /// A state whose session could not be determined must never be written: `load()` would reject
+    /// it, so persisting it only destroys what was there.
+    func testAStateWithNoSessionIsNeverWritten() throws {
+        write(state(session: WorkspaceMemory.session(),
+                    windows: ["42": .init(workspace: "A", bundleId: "com.apple.finder")]))
+        let before = try Data(contentsOf: WorkspaceMemory.fileUrl)
+        WorkspaceMemory.load()
+
+        WorkspaceMemory.writeForTests(state(session: "", windows: [:]))
+        WorkspaceMemory.waitForWrites()
+
+        assertEquals(try Data(contentsOf: WorkspaceMemory.fileUrl), before)
+    }
+
+    /// Failing to identify the session is not proof the file is stale. Deleting it on that basis
+    /// destroys a perfectly good memory whenever the process table read happens to fail.
+    func testAnUnidentifiableLiveSessionLeavesTheFileAlone() throws {
+        write(state(session: "ws:1:1.1", windows: ["42": .init(workspace: "A", bundleId: "com.apple.finder")]))
+        WorkspaceMemory.forceSessionForTests("")
+
+        WorkspaceMemory.load()
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: WorkspaceMemory.fileUrl.path),
+            "the file was deleted because we could not read the session, not because it was stale",
+        )
+        assertEquals(WorkspaceMemory.workspace(forWindowId: 42, bundleId: "com.apple.finder"), nil)
+    }
+
+    /// `save()` must record the monitor each workspace is on, or a restore has only half of what it
+    /// needs — the half whose absence forced the previous version to be reverted.
+    ///
+    /// Tested against the extracted helper: a headless suite has no windows, so a full `save()`
+    /// always yields an empty map and cannot see this at all.
+    func testTheSnapshotRecordsEachWorkspacesMonitor() {
+        let workspace = Workspace.get(byName: "A")
+        workspace.assignMonitor(testMonitors[1])
+
+        let recorded = WorkspaceMemory.workspaceMonitors(for: ["A"])
+
+        assertEquals(recorded["A"]?.displayUUID, rightUuid)
+    }
+
+    // MARK: - The hook
+
+    /// The restore is only reachable through `MacWindow.getOrRegister`, which needs a real
+    /// Accessibility window, so this pins the call *shape* in the source.
+    ///
+    /// A grep for the function name alone is not enough, and the previous version proved it: passing
+    /// `bundleId: nil` makes every lookup reject its entry — the feature permanently dead — while the
+    /// name is still there. So the arguments are pinned too, whitespace-normalised.
+    func testWindowRegistrationRestoresUsingTheWindowsOwnApp() throws {
+        let source = try String(
+            contentsOf: projectRoot.appending(path: "Sources/AppBundle/tree/MacWindow.swift"),
+            encoding: .utf8,
+        )
+        let normalised = source.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        XCTAssertTrue(
+            normalised.contains(
+                "WorkspaceMemory.restoredWorkspace(forWindowId: windowId, bundleId: macApp.bundleId)",
+            ),
+            """
+            window registration does not consult the memory with this window's own id and app.
+            Passing anything else -- `nil` in particular -- makes every lookup fail and the feature
+            silently does nothing.
+            """,
+        )
+    }
+
+    /// And the result has to be what the window is bound to, not something computed and dropped.
+    func testTheRestoredWorkspaceIsWhatTheWindowIsBoundTo() throws {
+        let source = try String(
+            contentsOf: projectRoot.appending(path: "Sources/AppBundle/tree/MacWindow.swift"),
+            encoding: .utf8,
+        )
+        let normalised = source.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        XCTAssertTrue(
+            normalised.contains(
+                "? WorkspaceMemory.restoredWorkspace(forWindowId: windowId, bundleId: macApp.bundleId) "
+                    + "?? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace",
+            ),
+            """
+            the remembered workspace is not the value bound to the window -- location is being used
+            regardless, so the memory is computed and thrown away.
+            """,
+        )
+    }
+
+    /// Restoring the name without the monitor is the reverted defect. `restoredWorkspace` is the one
+    /// entry point that does both, so the raw name lookup must not be what registration calls.
+    func testWindowRegistrationDoesNotUseTheNameOnlyLookup() throws {
+        let source = try String(
+            contentsOf: projectRoot.appending(path: "Sources/AppBundle/tree/MacWindow.swift"),
+            encoding: .utf8,
+        )
+        XCTAssertFalse(
+            source.contains("WorkspaceMemory.workspace(forWindowId:"),
+            "registration takes the workspace name without its monitor -- that collapses every "
+                + "restored workspace onto the main display",
+        )
+    }
+
+    /// `load()` must be called, and before anything can register a window.
+    func testLoadIsCalledAtStartupBeforeRegistrationCanHappen() throws {
+        let source = try String(
+            contentsOf: projectRoot.appending(path: "Sources/AppBundle/initAppBundle.swift"),
+            encoding: .utf8,
+        )
+        let load = try XCTUnwrap(
+            source.range(of: "WorkspaceMemory.load()")?.lowerBound,
+            "nothing loads the memory, so the whole feature is inert",
+        )
+        let observers = try XCTUnwrap(source.range(of: "GlobalObserver.initObserver()")?.lowerBound)
+        XCTAssertLessThan(load, observers, "windows can be registered before the memory is loaded")
+    }
+
+    /// The refresh-time save is what covers a crash or force quit, neither of which reaches the quit
+    /// path at all.
+    func testTheRefreshLoopPersistsTheTree() throws {
+        let source = try String(
+            contentsOf: projectRoot.appending(path: "Sources/AppBundle/layout/refresh.swift"),
+            encoding: .utf8,
+        )
+        XCTAssertTrue(
+            source.contains("WorkspaceMemory.save()"),
+            "nothing persists between quits, so a crash or `killall -9` loses the layout",
+        )
+    }
+
+    func testTheQuitPathSnapshotsBeforeTheCleanupMovesAnything() throws {
+        let source = try String(
+            contentsOf: projectRoot.appending(path: "Sources/AppBundle/util/appBundleUtil.swift"),
+            encoding: .utf8,
+        )
+        let save = try XCTUnwrap(source.range(of: "WorkspaceMemory.freezeAndSave()")?.lowerBound)
+        let cleanup = try XCTUnwrap(source.range(of: "makeAllWindowsVisibleAndRestoreSize()")?.lowerBound)
+        XCTAssertLessThan(save, cleanup, "the snapshot must be taken before the windows are moved")
+    }
+}

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -396,7 +396,27 @@ While a workspace is not active, all of its windows sit outside the visible area
 the bottom right or left corner.
 Switching back to the workspace (with the xref:commands.adoc#workspace[workspace] command, or `cmd + tab`) returns its windows to the visible area.
 
-On quit, and when AeroSpork detects that it is about to crash, all windows are returned to the visible area of the screen.
+On quit, and when AeroSpork detects that it is about to crash, all windows are returned to the
+visible area of the screen, each centred on the monitor it was on.
+
+[#workspace-memory]
+=== Workspaces across a restart
+
+AeroSpork remembers which workspace each window was on and puts it back when it restarts, along with
+the monitor that workspace was on.
+
+The memory is keyed on the window id issued by the macOS window server, so it holds for exactly as
+long as that server does. Restarting AeroSpork -- an update, a crash, `killall`, or Quit from the
+menu bar -- keeps it. Logging out, restarting the Mac, or quitting and relaunching an *application*
+does not: those windows are new as far as the system is concerned, and there is no way to recognise
+them. AeroSpork does not guess. It falls back to placing a window by where it physically sits, which
+is what it did before.
+
+For windows that must land somewhere specific after their app restarts, say so explicitly with
+xref:guide.adoc#on-window-detected-callback[on-window-detected] and `if.during-aerospork-startup`.
+
+The state lives in `/tmp` and is disposable: deleting it costs you one restart's worth of placement
+and nothing else.
 
 The name of the active workspace is shown in the menu bar icon.
 


### PR DESCRIPTION
Second attempt. The first (#16) was reverted in #18 for restoring the workspace name without its
monitor. Both halves are here, and the tests are rebuilt because the last set was theatre.

## What it does

Restarting AeroSpork scattered windows — one left on `A` came back on `1` or `3`. That was
structural: at a cold start no workspace is active, so `getStubWorkspace` invents one per monitor
from the first keybound name in sort order, and `A` sorts after every digit.

Windows return to their workspace, and that workspace to its monitor.

## The key

`CGWindowID`, and nothing else. It comes from a monotonic counter owned by **WindowServer**, so it
is stable across a restart of *this* process and meaningless afterwards. The generation token is
WindowServer's pid and start time, **not** `kern.boottime` — the counter restarts on logout,
`killall WindowServer` and graphics faults, none of which reboot the machine, and the kernel also
*adjusts* `boottime` when the clock is stepped.

A composite key can't substitute: `AXIdentifier` names a window *class*, so several identical
terminal windows are indistinguishable and a fuzzy key would permute them silently. An exact id match
cannot be wrong, only absent — every failure degrades to today's behaviour.

## Fixed after adversarial review

- **Two `Task.detached` writes raced.** Measured: the *older* snapshot won 240/500, and the change
  check — already updated — suppressed every correction. Writes are serial now, and the quit-time
  save waits on that queue, which drains anything the cleanup's own refresh had scheduled.
- **The snapshot ran before the change check**, so every refresh paid for a `MonitorFingerprint` per
  workspace (four CoreGraphics round trips each) on the main thread at up to 20 Hz during a drag —
  measured p99 19 ms, max 80 ms. Split into a cheap key compared first; the session is cached.
- **An unreadable session was destructive at both ends** — written into the file, and on read an
  empty *live* token deleted a good file, treating failure to look as proof of staleness.

## The tests

The previous suite was worthless and I repeated the mistake: I mutation-tested `saveBlocking`, a
function whose own comment says "Test seam", while `save()` — what `refresh.swift` calls — had zero
coverage. Deleting `load()` left everything green.

Now killed: `save()` emptied, the write deleted, `isLoaded` dropped, freeze check dropped, `load()`
removed, `save()` removed from refresh, `bundleId: nil`, monitors never recorded, the UUID branch
deleted, a constant session token, and five more attacking the monitor half.

Two needed a second pass: the freeze test was defeated by my own change-check early-out, and nothing
verified monitors were *recorded* (a headless suite has no windows, so a full `save()` always yields
an empty map — the recording half is now extracted and tested directly).

One mutation survives and is *equivalent*: swapping the two statements in `freezeAndSave`. The
restructure made that function write unconditionally, so the order no longer carries meaning.

## Documented

`docs/guide.adoc` gains a section stating plainly what does **not** survive — logout, reboot, or an
application relaunching — and points at `on-window-detected` with `if.during-aerospork-startup` for
those. `CLAUDE.md` records why the name alone was not enough, so the reverted defect is not
reintroduced.

`./run-tests.sh` green.