### PR TITLE
Publish 1.1.5 in the appcast

### DIFF
--- a/updates-site/appcast.xml
+++ b/updates-site/appcast.xml
@@ -6,6 +6,15 @@
         <description>Updates for AeroSpork, an i3-like tiling window manager for macOS.</description>
         <language>en</language>
         <item>
+            <title>1.1.5</title>
+            <pubDate>Thu, 30 Jul 2026 14:18:27 -0500</pubDate>
+            <link>https://github.com/wbsmolen/aerospork</link>
+            <sparkle:version>1.1.5</sparkle:version>
+            <sparkle:shortVersionString>1.1.5</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.5/AeroSpork-1.1.5.zip" length="6298579" type="application/octet-stream" sparkle:edSignature="XYCDlGjjpCnKAbPSqzkf09uCQQ8HQrUbHsn7TqT2+SuCfulIspvOTaNoZe8YJ7KuMcflak27JIEyvagAdFzvDg=="/>
+        </item>
+        <item>
             <title>1.1.4</title>
             <pubDate>Thu, 30 Jul 2026 12:32:06 -0500</pubDate>
             <link>https://github.com/wbsmolen/aerospork</link>
@@ -22,15 +31,6 @@
             <sparkle:shortVersionString>1.1.3</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
             <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.3/AeroSpork-1.1.3.zip" length="6241508" type="application/octet-stream" sparkle:edSignature="CWzb0IrprQyI9Fy1o6H1xyUEy58lfqvdEjVC8HbmOajBA+Ecf+qRkFumXsW3PyFVv1OTf/nNmVwdl1lrQiMzAQ=="/>
-        </item>
-        <item>
-            <title>1.1.2</title>
-            <pubDate>Thu, 30 Jul 2026 10:37:16 -0500</pubDate>
-            <link>https://github.com/wbsmolen/aerospork</link>
-            <sparkle:version>1.1.2</sparkle:version>
-            <sparkle:shortVersionString>1.1.2</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.2/AeroSpork-1.1.2.zip" length="6244875" type="application/octet-stream" sparkle:edSignature="FNi2ixPS0TcZ+XdjFCA4BQ9uKPwk1mnpST75MGU0qNQD1exb0nIahx52aG/8frSfuTGx6B4bBuWeCVsk2VKTDA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Verified against the asset GitHub actually serves: `sign_update --verify` exits 0 for `AeroSpork-1.1.5.zip` and non-zero for the distribution zip.