### PR TITLE
Ship the licence, and stop the docs telling people the install is broken

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,8 +235,10 @@ instructions live in `docs/guide.adoc` → *Troubleshooting and bug reports*.
 
 ## Dependencies
 
-Managed via Swift Package Manager (Package.swift). The only third-party dependency is:
+Managed via Swift Package Manager (Package.swift). Two third-party dependencies, both pinned exactly:
 - **TOMLKit**: TOML parsing
+- **Sparkle**: in-app updates (see *In-app updates* above -- it is the reason `Contents/Frameworks`
+  exists and why the release script signs nested code deepest-first)
 
 Everything else is native: Unix-socket IPC (POSIX), global hotkeys (Carbon), volume control (CoreAudio), ordered collections (plain Swift).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p>
   <img alt="macOS 13+" src="https://img.shields.io/badge/macOS-13%2B-000?logo=apple&logoColor=white">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
-  <a href="legal/LICENSE.txt"><img alt="MIT" src="https://img.shields.io/badge/license-MIT-blue"></a>
+  <a href="LICENSE.txt"><img alt="MIT" src="https://img.shields.io/badge/license-MIT-blue"></a>
 </p>
 
 </div>
@@ -91,6 +91,16 @@ The price is that the Mac App Store is permanently out: private symbols fail rev
 Accessibility APIs this app is built on do not work in a sandbox anyway. Hence Developer ID signing,
 notarization, and Sparkle rather than TestFlight.
 
+**Workspace placement survives a restart of AeroSpork.** Workspaces are emulated, so nothing
+outside the process knows a window belongs to one; at a cold start a window is bound by where it
+physically sits, and the workspace chosen for each monitor is the first key-bound name in sort order
+— which a named workspace like `A` can never be. Placement is now remembered, keyed on the window id
+the macOS window server issues. That id is stable for exactly as long as that server runs, so an
+update, a crash or a Quit keeps it and a logout, a reboot or an application relaunching does not.
+Where the id is gone there is no honest way to recognise a window — every terminal window reports the
+same accessibility identifier — so it falls back to placing by location rather than guessing, and
+`on-window-detected` remains the way to state intent.
+
 **The Xcode project is generated, not committed.** `project.yml` plus XcodeGen produces it, because
 SwiftPM cannot build an app bundle but a checked-in `.pbxproj` is a merge conflict waiting to happen.
 Debug builds skip Xcode entirely.
@@ -121,6 +131,7 @@ behave the same way. Only the deltas are listed.
 | Notarized builds | ❌ | ✅ &nbsp;signed, notarized, stapled |
 | Third-party dependencies | 4 | **2** |
 | Config schema | one syntax | v2 shorthand, older syntax still parses |
+| Windows keep their workspace across a restart | ❌ | ✅ &nbsp;also their monitor |
 | Command surface | **larger** | smaller |
 | Maturity | **public beta, larger community** | younger fork |
 
@@ -163,8 +174,7 @@ Download the notarized universal (arm64 + x86_64) build from the
 brew install --cask wbsmolen/tap/aerospork
 ```
 
-The tap is still private, so the cask currently needs an account with access. The releases on this
-repository are public, so the download above works for anyone.
+Both the tap and this repository are public, so either route works without a GitHub account.
 
 Installed copies check for updates themselves through [Sparkle](https://sparkle-project.org),
 against a signed appcast served from
@@ -264,5 +274,5 @@ strategy and performance measurement.
 ## License
 
 MIT. The original AeroSpace copyright is retained alongside the fork's in
-[`legal/LICENSE.txt`](legal/LICENSE.txt). Active development; features and configuration may still
+[`LICENSE.txt`](LICENSE.txt). Active development; features and configuration may still
 change.

--- a/build-release.sh
+++ b/build-release.sh
@@ -256,6 +256,32 @@ for required_path in "${required_paths[@]}"; do
     fi
 done
 
+# The package around the bundle needs the same treatment. A dead symlink is the failure mode that
+# already shipped: `test -e` follows links, so this catches both "absent" and "points at nothing".
+check-package-contents() {
+    local root="$1"
+    local required=(
+        legal/LICENSE.txt
+        legal/third-party-license
+        bin/aerospork
+        manpage/aerospork.1
+        shell-completion/zsh/_aerospork
+    )
+    for path in "${required[@]}"; do
+        if ! test -e "$root/$path"; then
+            echo "!!! Missing or dangling in the release package: $path !!!"
+            exit 1
+        fi
+    done
+    local dangling
+    dangling=$(find "$root" -type l ! -exec test -e {} \; -print)
+    if test -n "$dangling"; then
+        echo "!!! Dangling symlinks in the release package !!!"
+        echo "$dangling"
+        exit 1
+    fi
+}
+
 # Nested Mach-O code outside Contents/MacOS needs its own signature and is the classic
 # notarization rejection. Extra *data* resources are harmless, so they are not an error.
 #
@@ -320,7 +346,11 @@ notarize .release/AeroSpork.app
 ############
 
 mkdir -p ".release/aerospork-v$build_version/manpage" && cp .man/*.1 ".release/aerospork-v$build_version/manpage"
-cp -R ./legal ".release/aerospork-v$build_version/legal"
+# -RL, not -R: `legal/LICENSE.txt` is a symlink to the repo-root LICENSE.txt, which is NOT
+    # copied into the package -- so preserving the link shipped a dead one and the app's own MIT
+    # notice, carrying both copyright lines, was absent from every release. Dereferencing
+    # materialises it.
+    cp -RL ./legal ".release/aerospork-v$build_version/legal"
 cp -R ./shell-completion ".release/aerospork-v$build_version/shell-completion"
 cd .release
     cp -R AeroSpork.app "aerospork-v$build_version"
@@ -330,6 +360,7 @@ cd .release
     # gets a working ./bin/aerospork.
     mkdir -p "aerospork-v$build_version/bin"
     ln -sf "../AeroSpork.app/Contents/MacOS/aerospork-cli" "aerospork-v$build_version/bin/aerospork"
+    check-package-contents "aerospork-v$build_version"
     zip -ry "aerospork-v$build_version.zip" "aerospork-v$build_version"
 
     # A SECOND archive, for Sparkle only. The zip above is a distribution bundle: the .app sits

--- a/docs/config-examples/i3-like-config-example.toml
+++ b/docs/config-examples/i3-like-config-example.toml
@@ -11,7 +11,7 @@ enable-normalization-opposite-orientation-for-nested-containers = false
 on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 
 [mode.main.binding]
-    # See: https://github.com/wbsmolen/aerospork/blob/main/docs/goodies#open-a-new-window-with-applescript
+    # See: https://github.com/wbsmolen/aerospork/blob/main/docs/goodies.adoc#open-a-new-window-with-applescript
     alt-enter = '''exec-and-forget osascript -e '
     tell application "Terminal"
         do script
@@ -44,7 +44,7 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
     alt-shift-space = 'layout floating tiling' # 'floating toggle' in i3
 
     # Not supported, because this command is redundant in AeroSpork mental model.
-    # See: https://github.com/wbsmolen/aerospork/blob/main/docs/guide#floating-windows
+    # See: https://github.com/wbsmolen/aerospork/blob/main/docs/guide.adoc#floating-windows
     #alt-space = 'focus toggle_tiling_floating'
 
     # `focus parent`/`focus child` are not yet supported, and it's not clear whether they

--- a/docs/goodies.adoc
+++ b/docs/goodies.adoc
@@ -142,6 +142,7 @@ To open *a new window* of a program that supports multiple windows (Safari, Term
 +
 [source,toml]
 ----
+[mode.main.binding]
 ctrl-g = '''exec-and-forget osascript -e '
 tell application "Safari"
     make new document at end of documents
@@ -153,6 +154,7 @@ end tell'
 +
 [source,toml]
 ----
+[mode.main.binding]
 ctrl-g = '''exec-and-forget osascript -e '
 tell application "Terminal"
     do script
@@ -183,6 +185,7 @@ Bind a shortcut to `screencapture`, a built-in macOS command.
 .~/.aerospork.toml
 [source,toml]
 ----
+[mode.main.binding]
 alt-shift-s = 'exec-and-forget screencapture -i -c'
 ----
 

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -31,28 +31,23 @@ The cask installs the app, links the bundled CLI onto your `PATH`, and installs 
 the bash, fish and zsh completions. Your shell may need configuring to pick up Homebrew's
 completions: https://docs.brew.sh/Shell-Completion
 
-NOTE: The tap and the release repository are both private while AeroSpork is in early release, so
-`brew install` only works for accounts with access. Everyone else should use the manual
-installation above. The release zip carries the same completions under
+NOTE: The release zip carries the same completions under
 `aerospork-v$VERSION/shell-completion/`.
 
-If you see this message
+Releases are signed with a Developer ID, notarized by Apple and stapled, so Gatekeeper accepts
+them on first launch and you should not see a warning.
+
+If you do see
 
 ----
 "AeroSpork.app" can't be opened because Apple cannot check it for malicious software.
 ----
 
-**Option 1** to resolve the problem
-
-```
-xattr -d com.apple.quarantine /Applications/AeroSpork.app
-```
-
-**Option 2** to resolve the problem
-
-. Navigate in Finder to `/Applications/AeroSpork.app`
-. Right click
-. Open
+then the copy you have is not one of those -- a build from source, or a download that was altered in
+transit. Prefer replacing it with a release from the
+https://github.com/wbsmolen/aerospork/releases[releases page] over dismissing the warning: right
+click the app in Finder and choose Open to run it anyway, which is a decision to trust that
+particular copy.
 
 [#configuring-aerospork]
 == Configuring AeroSpork
@@ -396,8 +391,9 @@ While a workspace is not active, all of its windows sit outside the visible area
 the bottom right or left corner.
 Switching back to the workspace (with the xref:commands.adoc#workspace[workspace] command, or `cmd + tab`) returns its windows to the visible area.
 
-On quit, and when AeroSpork detects that it is about to crash, all windows are returned to the
-visible area of the screen, each centred on the monitor it was on.
+On quit, all windows are returned to the visible area of the screen, each centred on the monitor it
+was on. A crash does not run that cleanup -- nothing intercepts a fatal signal -- so windows can be
+left off screen; relaunching AeroSpork brings them back.
 
 [#workspace-memory]
 === Workspaces across a restart


### PR DESCRIPTION
From a full repo/docs inventory. Three blocking, plus the release-packaging bug that shipped in every
version.

## The MIT licence is absent from every release

`legal/LICENSE.txt` is a **symlink** to the repo-root `LICENSE.txt`, which is never copied into the
package — so `cp -R` preserved a link that dangles the moment the zip is unpacked. Confirmed in the
shipped v1.1.5 archive:

```
$ ls -l aerospork-v1.1.5/legal/LICENSE.txt
... legal/LICENSE.txt ⇒ ../LICENSE.txt [Dead link]
```

Four third-party licences ship; this project's own — carrying both copyright lines — does not.
`cp -RL` materialises it, and the package now gets the same contents check the app bundle already
has, plus a refusal on any dangling symlink. The guard was verified against a synthetic copy of the
exact failure.

The README badge and licence link pointed at the same symlink, which **GitHub renders as a 14-byte
stub**, not the licence.

## The docs say the install doesn't work

- `README.md:166` — "The tap is still private, so the cask currently needs an account with access."
- `docs/guide.adoc:34` — "The tap and the release repository are both private…"

Both repositories are public. The tap cask is at 1.1.5 with a sha matching the release asset, and an
anonymous fetch works. Two documents were telling every reader the headline install is unavailable.

## The guide describes crash handling that does not exist

> "when AeroSpork detects that it is about to crash, all windows are returned…"

Only `SIGINT` and `SIGTERM` are intercepted — no `SIGSEGV`/`SIGABRT`/`SIGBUS`/`SIGILL` handler exists
anywhere, and `refresh.swift`'s own comment says a crash never reaches the quit path. Now says what
happens, and that relaunching recovers.

It also still prescribed `xattr -d com.apple.quarantine`. Releases are notarized and stapled so that
warning shouldn't appear, and `build-release.sh` documents removing that exact workaround because
Homebrew rejects casks that strip quarantine.

## Also

- `CLAUDE.md` said TOMLKit was the only third-party dependency — in the section read before touching
  dependencies, sixty lines after a long note about Sparkle.
- Three `goodies.adoc` TOML examples showed bare bindings with no `[mode.main.binding]`; pasted as
  shown they're a **fatal** unknown-top-level-key error. Two links in the shipped example config were
  missing `.adoc` and 404'd. All 23 doc TOML blocks now parse (checked with `tomllib`), and both
  corrected URLs return 200.
- The README gains the workspace-persistence delta — upstream has no equivalent.

Two blocks the audit flagged were **not** wrong: `after-startup-command` and `exec-on-workspace-change`
are valid top-level keys, so those examples are correct as-is.

`./run-tests.sh` green, docs build clean, 38 man pages.