### PR TITLE
Stop one bracket in a string disabling every config-writer refusal

### DIFF
--- a/Sources/AppBundle/config/ConfigurationWriter.swift
+++ b/Sources/AppBundle/config/ConfigurationWriter.swift
@@ -189,6 +189,41 @@ enum ConfigurationWriter {
         (try? TOMLTable(string: base)).map(isConfigV2) ?? false
     }
 
+    /// Net unclosed `[` on a line, ignoring anything inside a string or after a `#`.
+    ///
+    /// Counting the raw text conflated three different brackets: an array's, one inside a regex
+    /// (`'\\[Debug'` is an ordinary window-title matcher), and one in a comment. A bracket in a
+    /// string left the depth stuck above zero, and since the scan `continue`s while the depth is
+    /// positive, every later line was skipped and `unsupportedShapeReason` returned nil for the
+    /// rest of the file -- disabling the fingerprint refusal, whose own comment records that its
+    /// absence damaged a real config. A bracket in a comment did the mirror opposite and refused a
+    /// file that was fine.
+    ///
+    /// Deliberately not a TOML parser: it tracks the quoting well enough that a value cannot lie
+    /// about structure, which is all the caller needs.
+    static func bracketBalance(_ line: String) -> Int {
+        var depth = 0
+        var quote: Character? = nil
+        var escaped = false
+        for character in line {
+            if let open = quote {
+                // Escapes only apply inside basic strings; TOML literal strings ('...') take none.
+                if escaped { escaped = false; continue }
+                if open == "\"" && character == "\\" { escaped = true; continue }
+                if character == open { quote = nil }
+                continue
+            }
+            switch character {
+                case "\"", "'": quote = character
+                case "#": return depth // rest of the line is a comment
+                case "[": depth += 1
+                case "]": depth -= 1
+                default: break
+            }
+        }
+        return depth
+    }
+
     static func unsupportedShapeReason(_ text: String) -> String? {
         let managedSections = ["gaps", "exec", "key-mapping", "workspace-to-monitor-force-assignment", "monitors", "on-window"]
         let managedScalars = [
@@ -233,7 +268,7 @@ enum ConfigurationWriter {
 
             // Inside a multi-line value: consume until the brackets balance.
             if openBracketDepth > 0 {
-                openBracketDepth += line.count(where: { $0 == "[" }) - line.count(where: { $0 == "]" })
+                openBracketDepth += bracketBalance(line)
                 continue
             }
             if line.isEmpty || line.hasPrefix("#") { continue }
@@ -255,7 +290,7 @@ enum ConfigurationWriter {
             let value = String(line[line.index(after: eq)...]).trimmingCharacters(in: .whitespaces)
 
             // Multi-line array: `setScalar`/`removeBindingLine` rewrite line 1 and orphan the rest.
-            let opens = value.count(where: { $0 == "[" }) - value.count(where: { $0 == "]" })
+            let opens = bracketBalance(value)
             if opens > 0 {
                 if section.isEmpty, managedScalars.contains(key) {
                     return "'\(key)' is written as a multi-line array, which this editor cannot rewrite safely. Use the Raw TOML tab."
@@ -319,6 +354,16 @@ enum ConfigurationWriter {
                 if let extra = fields.first(where: { value.contains($0) }) {
                     return "Monitor assignment '\(key)' pins a display by '\(extra)', which this editor cannot represent and would replace with just a name. Use the Raw TOML tab."
                 }
+            }
+
+            // A list of candidates is tried in order until one resolves. The view model keeps only
+            // `.first`, and editing ANY assignment re-serialises the whole section -- so one edit
+            // silently drops every other row's fallbacks too. Same class as the fingerprint case
+            // above, and the same answer: refuse rather than degrade.
+            if section == "monitors" || section == "workspace-to-monitor-force-assignment",
+               value.hasPrefix("[")
+            {
+                return "Monitor assignment '\(key)' lists fallback monitors, and this editor keeps only the first. Use the Raw TOML tab."
             }
 
             // A key inside a rewritten section that we do not re-emit would simply vanish.
@@ -427,9 +472,14 @@ enum ConfigurationWriter {
     /// appended a fresh one -- two copies of the rule, and since the shorthand is parsed last, the
     /// *stale* one won. The user's edit did nothing and their config grew on every save.
     private static func arrayOfTablesHeaderName(_ line: String) -> String? {
-        let t = line.trimmingCharacters(in: .whitespaces)
+        let t = stripTrailingComment(line)
         guard t.hasPrefix("[["), t.hasSuffix("]]") else { return nil }
-        return String(t.dropFirst(2).dropLast(2)).trimmingCharacters(in: .whitespaces)
+        let inner = String(t.dropFirst(2).dropLast(2)).trimmingCharacters(in: .whitespaces)
+        // `[["on-window-detected"]]` is the same table as the bare spelling.
+        if inner.count >= 2, inner.hasPrefix("\""), inner.hasSuffix("\"") {
+            return String(inner.dropFirst().dropLast())
+        }
+        return inner
     }
 
     /// Removes every `[[name]]` block. `removeSections` deliberately ignores array-of-table headers,
@@ -691,8 +741,28 @@ enum ConfigurationWriter {
 
     /// Name of a single-bracket table header (`[gaps]` -> "gaps"). Returns nil for array-of-table
     /// headers (`[[...]]`) and non-header lines, so those are never matched or split.
+    /// A header may carry a trailing comment -- `[gaps] # tuned for the 32"` is legal TOML and
+    /// TOMLKit reads it. Matching on `hasSuffix("]")` missed those, so the section was never removed
+    /// and the writer appended a second copy beside it. For `[on-window]` that means every rule in
+    /// the table applies twice, which is the exact bug an earlier commit set out to fix.
+    private static func stripTrailingComment(_ line: String) -> String {
+        var result = ""
+        var quote: Character? = nil
+        for character in line {
+            if let open = quote {
+                result.append(character)
+                if character == open { quote = nil }
+                continue
+            }
+            if character == "#" { break }
+            if character == "\"" || character == "'" { quote = character }
+            result.append(character)
+        }
+        return result.trimmingCharacters(in: .whitespaces)
+    }
+
     private static func sectionHeaderName(_ line: String) -> String? {
-        let t = line.trimmingCharacters(in: .whitespaces)
+        let t = stripTrailingComment(line)
         guard t.hasPrefix("["), t.hasSuffix("]"), !t.hasPrefix("[[") else { return nil }
         return String(t.dropFirst().dropLast()).trimmingCharacters(in: .whitespaces)
     }

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -780,6 +780,104 @@ final class ConfigTest: XCTestCase {
         XCTAssertTrue(out.contains("42"), "a line the GUI could not read was deleted:\n\(out)")
     }
 
+    /// A `[` inside a string value used to blind every refusal after it.
+    ///
+    /// `unsupportedShapeReason` counts brackets over the raw text to detect a multi-line array, so
+    /// an escaped bracket in a regex -- `'\\[Debug'`, an ordinary thing to write in a window-title
+    /// matcher -- left the depth stuck above zero and every later line was skipped. The guard then
+    /// returned nil for the rest of the file, including the fingerprint check whose own comment
+    /// records that its absence "shipped, and it damaged a real config".
+    func testABracketInsideAStringDoesNotBlindTheShapeGuard() {
+        let config = """
+            [[on-window-detected]]
+            if.window-title-regex-substring = '\\[Debug'
+            run = ['layout floating']
+
+            [monitors]
+            2 = { fingerprint = { display_name = 'ACME Display 32 (1)', width = 3840, height = 2160 } }
+            """
+        let reason = ConfigurationWriter.unsupportedShapeReason(config)
+        XCTAssertNotNil(
+            reason,
+            "the fingerprint refusal was skipped: a bracket in a string disabled every guard after it",
+        )
+        XCTAssertTrue(reason?.contains("width") == true || reason?.contains("display_name") == true, reason ?? "nil")
+    }
+
+    /// And the mirror image: a bracket in a comment must not refuse a perfectly good config.
+    func testABracketInACommentDoesNotRefuseTheConfig() {
+        let config = """
+            accordion-padding = 30 # TODO [
+            [gaps]
+            inner.horizontal = 10
+            """
+        assertEquals(ConfigurationWriter.unsupportedShapeReason(config), nil)
+    }
+
+    /// A real multi-line array must still be refused -- that is what the counting is for.
+    func testAGenuineMultiLineArrayIsStillRefused() {
+        let config = """
+            after-startup-command = [
+                'exec-and-forget echo hi',
+            ]
+            """
+        XCTAssertNotNil(ConfigurationWriter.unsupportedShapeReason(config))
+    }
+
+    /// A trailing comment on a header made the section unremovable, so the writer appended a second
+    /// copy beside it -- and for `[on-window]` that means every rule in the table applies twice.
+    func testAHeaderWithATrailingCommentIsStillReplaced() {
+        let base = """
+            mod = 'alt'
+
+            [on-window] # my rules
+            "com.apple.finder" = "move-node-to-workspace 3"
+            """
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: base)
+        vm.markLoaded()
+        assertEquals(vm.windowRules.count, 1)
+        vm.windowRules[0].run = "move-node-to-workspace 4"
+
+        let out = ConfigurationWriter.render(baseText: base, from: vm)
+        let (config, errors) = parseConfigForTest(out)
+        assertEquals(errors, [])
+        assertEquals(config.onWindowDetected.count, 1)
+        XCTAssertFalse(out.contains("move-node-to-workspace 3"), "the superseded rule survived:\n\(out)")
+    }
+
+    /// TOML lets a table name be quoted; it is the same table.
+    func testAQuotedArrayOfTablesHeaderIsStillReplaced() {
+        let base = """
+            [["on-window-detected"]]
+            if.app-id = 'com.apple.mail'
+            run = ['layout floating']
+            """
+        let vm = ConfigurationViewModel()
+        vm.loadWindowRules(fromText: base)
+        vm.markLoaded()
+        vm.windowRules[0].run = "layout tiling"
+
+        let out = ConfigurationWriter.render(baseText: base, from: vm)
+        let (config, errors) = parseConfigForTest(out)
+        assertEquals(errors, [])
+        assertEquals(config.onWindowDetected.count, 1)
+    }
+
+    /// A fallback list is tried in order until one monitor resolves, and the view model keeps only
+    /// the first. Since editing any assignment re-serialises the whole section, degrading instead of
+    /// refusing would silently truncate every other row too.
+    func testAMonitorFallbackListIsRefusedRatherThanTruncated() {
+        let config = """
+            [workspace-to-monitor-force-assignment]
+            1 = 'main'
+            2 = ['secondary', 'built-in']
+            """
+        let reason = ConfigurationWriter.unsupportedShapeReason(config)
+        XCTAssertNotNil(reason, "a fallback list would be silently reduced to its first entry")
+        XCTAssertTrue(reason?.contains("fallback") == true, reason ?? "nil")
+    }
+
     /// An *applied* Raw TOML tab is authoritative -- it is exactly what lands on disk.
     /// See `ConfigurationWriterSafetyTest` for the counterpart: an unapplied buffer must NOT win.
     func testWriterRawTomlWins() {

--- a/script/publish-release.sh
+++ b/script/publish-release.sh
@@ -1,15 +1,30 @@
 #!/bin/bash
+set -e
 cd "$(dirname "$0")/.."
 source ./script/setup.sh
 
+# Cuts a release: build, tag, publish both archives, sign the appcast, update the tap.
+#
+# It used to open a browser tab and ask you to drag one zip in. That lost two steps every time,
+# because a release is not one artifact:
+#
+#   * `aerospork-v$V.zip`  -- the distribution package Homebrew and manual installers take.
+#   * `AeroSpork-$V.zip`   -- the Sparkle update archive, the .app at the archive root. Sparkle
+#                             REFUSES the distribution zip ("only .app bundles are supported"), so
+#                             without this one, in-app updates are dead.
+#
+# and the appcast has to name the second one or nothing is offered at all. v1.1.0 shipped without
+# `AeroSpork-1.1.0.zip` -- and with the generated cask file uploaded as a release asset by mistake,
+# which is what happens when the step is "drag the right file in".
+
 build_version=""
+notes_file=""
 cask_git_repo_path=""
-site_git_repo_path=""
 while test $# -gt 0; do
     case $1 in
         --build-version) build_version="$2"; shift 2;;
+        --notes-file) notes_file="$2"; shift 2;;
         --cask-git-repo-path) cask_git_repo_path="$2"; shift 2;;
-        --site-git-repo-path) site_git_repo_path="$2"; shift 2;;
         *) echo "Unknown option $1"; exit 1;;
     esac
 done
@@ -18,36 +33,106 @@ if test -z "$build_version"; then
     echo "--build-version flag is mandatory" > /dev/stderr
     exit 1
 fi
-
-if ! test -d "$cask_git_repo_path"; then
-    echo "--cask-git-repo-path is a mandatory flag that must point to existing directory" > /dev/stderr
+if test -n "$notes_file" && ! test -f "$notes_file"; then
+    echo "--notes-file points at a file that does not exist: $notes_file" > /dev/stderr
     exit 1
 fi
 
-if ! test -d "$site_git_repo_path"; then
-    echo "--site-git-repo-path is a mandatory flag that must point to existing directory" > /dev/stderr
+repo="wbsmolen/aerospork"
+dist_zip=".release/aerospork-v$build_version.zip"
+sparkle_zip=".release/AeroSpork-$build_version.zip"
+
+for tool in gh swa az; do
+    command -v "$tool" > /dev/null || { echo "Required tool not found: $tool" > /dev/stderr; exit 1; }
+done
+
+# The build embeds `git rev-parse HEAD` and then asserts the binary contains it, so a commit landing
+# mid-build fails the release ~20 minutes in. Refuse up front instead.
+if test -n "$(git status --porcelain)"; then
+    echo "Working tree is dirty. A release must be built from a committed tree." > /dev/stderr
+    git status --short > /dev/stderr
     exit 1
 fi
 
 ./run-tests.sh
 ./build-release.sh --build-version "$build_version"
 
-git tag -a "v$build_version" -m "v$build_version" && git push git@github.com:wbsmolen/aerospork.git "v$build_version"
-link="https://github.com/wbsmolen/aerospork/releases/new?tag=v$build_version"
-open "$link" || { echo "$link"; exit 1; }
-sleep 1
-open -R "./.release/aerospork-v$build_version.zip"
+for artifact in "$dist_zip" "$sparkle_zip"; do
+    test -f "$artifact" || { echo "Missing build artifact: $artifact" > /dev/stderr; exit 1; }
+done
 
-echo "Please upload .zip to GitHub release and hit Enter"
-read -r
+git tag -a "v$build_version" -m "v$build_version"
+git push origin "v$build_version"
+
+if test -n "$notes_file"; then
+    gh release create "v$build_version" --repo "$repo" --title "AeroSpork $build_version" \
+        --notes-file "$notes_file" "$dist_zip" "$sparkle_zip"
+else
+    gh release create "v$build_version" --repo "$repo" --title "AeroSpork $build_version" \
+        --generate-notes "$dist_zip" "$sparkle_zip"
+fi
+
+##################
+### THE APPCAST ##
+##################
+
+# Generated from the Sparkle archive, never the distribution zip. `generate_appcast` re-uses an
+# appcast already present in the directory, so seeding it with the live one keeps the channel
+# metadata and the older items.
+appcast_workdir="$(mktemp -d)"
+trap 'rm -rf "$appcast_workdir"' EXIT
+cp "$sparkle_zip" "$appcast_workdir/"
+cp updates-site/appcast.xml "$appcast_workdir/appcast.xml"
+
+sparkle_bin="$(find .build/artifacts -type d -name bin -path '*sparkle*' | head -1)"
+test -n "$sparkle_bin" || { echo "Sparkle tools not found; run a build first" > /dev/stderr; exit 1; }
+
+"$sparkle_bin/generate_appcast" \
+    --download-url-prefix "https://github.com/$repo/releases/download/v$build_version/" \
+    --link "https://github.com/$repo" \
+    "$appcast_workdir"
+cp "$appcast_workdir/appcast.xml" updates-site/appcast.xml
+
+# The signature has to verify against the asset GitHub actually serves, not the local copy. A wrong
+# enclosure URL, a re-zipped artifact or a mismatched key all show up here and nowhere else.
+signature="$(grep -m1 -o 'edSignature="[^"]*"' updates-site/appcast.xml | sed 's/edSignature="//; s/"$//')"
+published="$appcast_workdir/published.zip"
+curl -fsSL -o "$published" "https://github.com/$repo/releases/download/v$build_version/AeroSpork-$build_version.zip"
+if ! "$sparkle_bin/sign_update" --verify "$published" "$signature" > /dev/null 2>&1; then
+    echo "!!! The appcast signature does not verify against the published asset !!!" > /dev/stderr
+    exit 1
+fi
+
+swa deploy updates-site \
+    --deployment-token "$(az staticwebapp secrets list --name aerospork-updates \
+        --resource-group aerospork-updates --query 'properties.apiKey' -o tsv)" \
+    --env production
+
+################
+### THE CASK ###
+################
 
 ./script/build-brew-cask.sh \
     --cask-name aerospork \
-    --zip-uri "https://github.com/wbsmolen/aerospork/releases/download/v$build_version/aerospork-v$build_version.zip" \
+    --zip-uri "https://github.com/$repo/releases/download/v$build_version/aerospork-v$build_version.zip" \
     --build-version "$build_version"
 
-eval "$cask_git_repo_path/pin.sh"
-cp -r .release/aerospork.rb "$cask_git_repo_path/Casks/aerospork.rb"
+if test -n "$cask_git_repo_path"; then
+    if ! test -d "$cask_git_repo_path"; then
+        echo "--cask-git-repo-path points at a directory that does not exist" > /dev/stderr
+        exit 1
+    fi
+    cp .release/aerospork.rb "$cask_git_repo_path/Casks/aerospork.rb"
+    echo "Cask copied into $cask_git_repo_path -- commit and push it there."
+else
+    # No local clone needed for a one-file change.
+    gh api -X PUT "repos/wbsmolen/homebrew-tap/contents/Casks/aerospork.rb" \
+        -f message="aerospork $build_version" \
+        -f content="$(base64 -i .release/aerospork.rb | tr -d '\n')" \
+        -f sha="$(gh api repos/wbsmolen/homebrew-tap/contents/Casks/aerospork.rb -q .sha)" > /dev/null
+    echo "Tap updated to $build_version."
+fi
 
-rm -rf "${site_git_repo_path:?}/*" # https://www.shellcheck.net/wiki/SC2115
-cp -r .site/* "$site_git_repo_path"
+echo
+echo "Published v$build_version. Remaining by hand:"
+echo "  * commit updates-site/appcast.xml"


### PR DESCRIPTION
Four defects from the triage pass. The first is the worst thing found in this file.

## One bracket in a string disabled every refusal after it

`unsupportedShapeReason` counted brackets over raw text to detect a multi-line array:

```swift
let opens = value.count(where: { $0 == "[" }) - value.count(where: { $0 == "]" })
```

A window-title matcher of `'\[Debug'` — an ordinary regex escape — leaves the depth at 1, and the
scan `continue`s past every line while the depth is positive. So the guard returned `nil` for the
**rest of the file**, including the fingerprint refusal whose own comment records that its absence
*"shipped, and it damaged a real config"*. With it blind, a
`{ fingerprint = { display_name, width, height } }` assignment is degraded to a bare name and
`validate` passes.

A bracket in a comment (`accordion-padding = 30 # TODO [`) did the mirror opposite and refused a
perfectly good config.

Both reproduced as failing tests before the fix. Counting is now quote- and comment-aware.

## A trailing comment made a section unremovable

`[on-window] # my rules` fails `hasSuffix("]")`, so the section was never removed and the writer
appended a long-form copy beside it — **every rule in that table then applies twice**. That is the
double-apply bug #14 fixed, reachable through one comment. Quoted array-of-table names
(`[["on-window-detected"]]`) had the same problem.

## Fallback monitor lists were silently truncated

`2 = ['secondary', 'built-in']` → `2 = 'secondary'`. The view model keeps `.first`, and editing *any*
assignment re-serialises the whole section — so one edit drops every other row's fallbacks too. Same
class as the fingerprint case, same answer: refuse rather than degrade.

## `publish-release.sh` could not cut a working release

It uploaded one archive and asked the operator to drag it in, leaving the Sparkle update archive and
the appcast to be remembered. **v1.1.0 shipped with no `AeroSpork-1.1.0.zip` at all** — and with the
generated cask file uploaded as a release asset by mistake.

It now publishes both archives, regenerates and signs the appcast, **verifies that signature against
the asset GitHub actually serves**, deploys it, and updates the tap. It also refuses to start from a
dirty tree: the build embeds the commit hash and asserts it, so a commit landing mid-build fails
twenty minutes in — which happened during 1.1.4.

Its site-repo cleanup was a no-op — the glob sat inside the quotes, so `rm -rf` got a literal `*`.

## Tests

Six new, all mutation-checked: disabling quote tracking, dropping the comment stop, not stripping
header comments, not unwrapping quoted names, and removing the fallback guard are each caught.

`./run-tests.sh` green.