### PR TITLE
Stop the startup save forgetting apps that have not launched yet

### DIFF
--- a/Sources/AppBundle/AppDelegate.swift
+++ b/Sources/AppBundle/AppDelegate.swift
@@ -29,6 +29,11 @@ public final class AeroSporkAppDelegate: NSObject, NSApplicationDelegate {
         // is what makes a logout appear to hang.
         Task {
             defer { sender.reply(toApplicationShouldTerminate: true) }
+            // If something else vetoes the logout, this process keeps running -- and would keep
+            // running with the memory frozen, so nothing would be saved again for the rest of the
+            // session. Cheap to make recoverable; `cleanupStarted` is deliberately not reset,
+            // because the window-restoring half of the cleanup is idempotent but not free.
+            defer { WorkspaceMemory.unfreezeAfterCancelledQuit() }
             do {
                 try await terminationHandler.beforeTermination()
             } catch {

--- a/Sources/AppBundle/WorkspaceMemory.swift
+++ b/Sources/AppBundle/WorkspaceMemory.swift
@@ -221,11 +221,18 @@ enum WorkspaceMemory {
     /// and the monitor list is rebuilt on every access, so this is only reached when `cheapKey`
     /// says something actually changed.
     private static func fullState(_ key: CheapKey) -> State {
-        State(
-            session: session(),
-            windows: key.windows,
-            workspaceMonitors: workspaceMonitors(for: Set(key.workspaceScreens.keys)),
-        )
+        var monitors = workspaceMonitors(for: Set(key.workspaceScreens.keys))
+        // Keep the remembered monitor for any workspace this snapshot cannot see yet. Dropping it
+        // would leave a restored window with its workspace and no monitor, which is precisely the
+        // half-restore that made the first version of this worse than no restore at all.
+        if let remembered = restored {
+            for (name, fingerprint) in remembered.workspaceMonitors where monitors[name] == nil {
+                if key.windows.values.contains(where: { $0.workspace == name }) {
+                    monitors[name] = fingerprint
+                }
+            }
+        }
+        return State(session: session(), windows: key.windows, workspaceMonitors: monitors)
     }
 
     /// The fingerprint of each named workspace's monitor.
@@ -266,7 +273,20 @@ enum WorkspaceMemory {
     /// do not.
     static func save() {
         guard isLoaded, !isFrozen else { return }
-        let key = cheapKey()
+        var key = cheapKey()
+        // During startup, add but never prune.
+        //
+        // AeroSpork launches alongside every other login item and macOS's own window restore, so an
+        // app that has not answered Accessibility yet is simply absent from this snapshot. Writing
+        // it as-is deletes that window's entry -- and since the memory is only consulted while
+        // `isStartup`, the window has already lost its one chance by the time it appears. Keeping
+        // the remembered entries means a slow app is restored when it does show up.
+        if isStartup, let remembered = restored {
+            key = CheapKey(
+                windows: remembered.windows.merging(key.windows) { _, new in new },
+                workspaceScreens: key.workspaceScreens,
+            )
+        }
         guard key != lastWritten else { return }
         lastWritten = key
         write(fullState(key), waitForCompletion: false)
@@ -287,6 +307,11 @@ enum WorkspaceMemory {
     /// pretending the session could not be read.
     static func writeForTests(_ state: State) { write(state, waitForCompletion: false) }
     static func forceSessionForTests(_ value: String) { cachedSession = value }
+
+    /// A quit that was asked for and then vetoed leaves us running. Without this the memory stays
+    /// frozen for the rest of the session, so a crash hours later restores the layout as it was at
+    /// the cancelled logout.
+    static func unfreezeAfterCancelledQuit() { isFrozen = false }
 
     /// Test seam: blocks until every queued write has landed, so a test can read the file back
     /// without racing the asynchronous path that production actually uses.

--- a/Sources/AppBundleTests/WorkspaceMemoryTest.swift
+++ b/Sources/AppBundleTests/WorkspaceMemoryTest.swift
@@ -54,6 +54,12 @@ final class WorkspaceMemoryTest: XCTestCase {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
+    /// Runs `body` as though AeroSpork were still starting up. `_isStartup` is a `@TaskLocal`, so
+    /// it is bound for the scope rather than assigned -- the same way `runRefreshSession` does it.
+    private func withStartup(_ body: () throws -> Void) rethrows {
+        try $_isStartup.withValue(true) { try body() }
+    }
+
     private func write(_ state: WorkspaceMemory.State) {
         try! JSONEncoder().encode(state).write(to: WorkspaceMemory.fileUrl)
     }
@@ -364,6 +370,69 @@ final class WorkspaceMemoryTest: XCTestCase {
         let recorded = WorkspaceMemory.workspaceMonitors(for: ["A"])
 
         assertEquals(recorded["A"]?.displayUUID, rightUuid)
+    }
+
+    /// At login, a window whose app has not answered Accessibility yet is absent from the startup
+    /// snapshot. Overwriting the file with that snapshot deletes its entry — and the memory is only
+    /// consulted while `isStartup`, so by the time the app appears its one chance is gone.
+    func testTheStartupSaveDoesNotPruneWindowsThatHaveNotAppearedYet() throws {
+        write(state(
+            session: WorkspaceMemory.session(),
+            windows: [
+                "42": .init(workspace: "A", bundleId: "com.apple.finder"),
+                "43": .init(workspace: "B", bundleId: "com.googlecode.iterm2"),
+            ],
+            monitors: ["A": fingerprint(uuid: rightUuid), "B": fingerprint(uuid: leftUuid)],
+        ))
+        WorkspaceMemory.load()
+
+        // A headless suite has no windows at all, which is exactly the "nothing has appeared yet"
+        // case: without the merge this save would write an empty map.
+        try withStartup {
+            WorkspaceMemory.save()
+            WorkspaceMemory.waitForWrites()
+        }
+
+        let data = try Data(contentsOf: WorkspaceMemory.fileUrl)
+        let written = try JSONDecoder().decode(WorkspaceMemory.State.self, from: data)
+        assertEquals(written.windows.count, 2)
+        assertEquals(written.windows["42"]?.workspace, "A")
+        // And the monitor must survive with it, or the window is restored with half its placement.
+        assertEquals(written.workspaceMonitors["A"]?.displayUUID, rightUuid)
+    }
+
+    /// Once startup is over, a window that has genuinely gone must be forgotten -- otherwise the
+    /// file grows without bound and stale ids linger for the whole session.
+    func testAfterStartupAWindowThatIsGoneIsForgotten() throws {
+        write(state(session: WorkspaceMemory.session(),
+                    windows: ["42": .init(workspace: "A", bundleId: "com.apple.finder")]))
+        WorkspaceMemory.load()
+
+        WorkspaceMemory.save() // not startup
+        WorkspaceMemory.waitForWrites()
+
+        let written = try JSONDecoder().decode(
+            WorkspaceMemory.State.self, from: try Data(contentsOf: WorkspaceMemory.fileUrl),
+        )
+        assertEquals(written.windows.count, 0)
+    }
+
+    /// A logout that another app vetoes leaves this process running. Staying frozen would mean
+    /// nothing is saved again for the rest of the session.
+    func testACancelledQuitLeavesTheMemoryWritable() throws {
+        WorkspaceMemory.load()
+        WorkspaceMemory.freezeAndSave()
+        try FileManager.default.removeItem(at: WorkspaceMemory.fileUrl)
+
+        WorkspaceMemory.unfreezeAfterCancelledQuit()
+        WorkspaceMemory.invalidateChangeCheckForTests()
+        WorkspaceMemory.save()
+        WorkspaceMemory.waitForWrites()
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: WorkspaceMemory.fileUrl.path),
+            "the memory stayed frozen after a cancelled quit, so nothing is saved for the rest of the session",
+        )
     }
 
     // MARK: - The hook


### PR DESCRIPTION
Two findings from the triage pass, both real.

## The feature did nothing on a cold boot

At login AeroSpork starts alongside every other login item and macOS's window restore, so an app that
has not answered Accessibility yet is absent from the first refresh. That snapshot was written as-is,
**deleting those windows' entries** — and `restoredWorkspace` is only consulted while `isStartup`, so
by the time the app appears its one chance is gone.

So the case the feature is wanted most for — a cold boot, where every app is racing — is the one it
silently skipped.

During startup the save now **merges rather than replaces**. Only during startup: afterwards a window
that has genuinely gone must be forgotten, or the file grows without bound and stale ids linger for
the session. The remembered monitor is carried across the same merge — keeping the workspace and
dropping the monitor is exactly the half-restore that made #16 worse than no restore at all.

## `isFrozen` was never reset

A logout runs `beforeTermination` via `applicationShouldTerminate`. If another app vetoes it, this
process keeps running with saving permanently disabled — so a crash hours later restores the layout
as it stood at the cancelled logout.

## Tests

Four mutations pinned:

| mutation | caught |
|---|---|
| startup merge removed | ✅ |
| monitor carry-over removed | ✅ |
| `unfreezeAfterCancelledQuit` made a no-op | ✅ |
| merge applied outside startup too | ✅ |

That last one matters: it is the plausible over-correction, and it grows the file forever.

`./run-tests.sh` green.