### PR TITLE
Put the release notes in Sparkle's update dialog

### DIFF
--- a/script/publish-release.sh
+++ b/script/publish-release.sh
@@ -84,10 +84,75 @@ trap 'rm -rf "$appcast_workdir"' EXIT
 cp "$sparkle_zip" "$appcast_workdir/"
 cp updates-site/appcast.xml "$appcast_workdir/appcast.xml"
 
+# Release notes, so the update dialog is not blank -- without them Sparkle shows an empty pane while
+# perfectly good notes sit on the GitHub release doing nothing.
+#
+# HTML, not Markdown. `generate_appcast` picks up a file named after the archive, but a `.md` beside
+# it is silently ignored: only `.html` (without DOCTYPE or body tags) is embedded as CDATA. Tested
+# both -- the Markdown run produced an item with no <description> at all and said nothing about it.
+if test -n "$notes_file"; then
+    python3 - "$notes_file" > "$appcast_workdir/AeroSpork-$build_version.html" <<'PYEOF'
+import html, re, sys
+
+# Deliberately not a Markdown library: these notes use headings, bullets, links, inline code and
+# fenced blocks, and pulling in a dependency to render five constructs for a dialog nobody reads
+# twice is not worth it.
+lines = open(sys.argv[1]).read().split("\n")
+out, in_list, in_code = [], False, False
+para: list[str] = []
+
+def flush():
+    if para:
+        out.append(f"<p>{inline(' '.join(para))}</p>")
+        para.clear()
+
+def inline(text: str) -> str:
+    text = html.escape(text)
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"<em>\1</em>", text)
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', text)
+    return text
+
+for line in lines:
+    if line.startswith("```"):
+        flush()
+        if in_list: out.append("</ul>"); in_list = False
+        out.append("</pre>" if in_code else "<pre>")
+        in_code = not in_code
+        continue
+    if in_code:
+        out.append(html.escape(line))
+        continue
+    stripped = line.strip()
+    if stripped.startswith("- "):
+        flush()
+        if not in_list: out.append("<ul>"); in_list = True
+        out.append(f"<li>{inline(stripped[2:])}</li>")
+        continue
+    if in_list: out.append("</ul>"); in_list = False
+    if stripped.startswith("#"):
+        flush()
+        level = min(len(stripped) - len(stripped.lstrip("#")), 6)
+        out.append(f"<h{level}>{inline(stripped.lstrip('#').strip())}</h{level}>")
+    elif stripped:
+        # Accumulated, not emitted per line: these notes are hard-wrapped, and one <p> per source
+        # line renders as a column of one-sentence fragments.
+        para.append(stripped)
+    else:
+        flush()
+flush()
+if in_list: out.append("</ul>")
+if in_code: out.append("</pre>")
+print("\n".join(out))
+PYEOF
+fi
+
 sparkle_bin="$(find .build/artifacts -type d -name bin -path '*sparkle*' | head -1)"
 test -n "$sparkle_bin" || { echo "Sparkle tools not found; run a build first" > /dev/stderr; exit 1; }
 
 "$sparkle_bin/generate_appcast" \
+    --embed-release-notes \
     --download-url-prefix "https://github.com/$repo/releases/download/v$build_version/" \
     --link "https://github.com/$repo" \
     "$appcast_workdir"


### PR DESCRIPTION
The update dialog showed an empty "what's new" pane — no `<item>` in the appcast had a
`<description>`, so the notes written for each GitHub release were invisible to the people actually
being prompted to update.

## Markdown is silently ignored

`generate_appcast` embeds a release-note file named after the archive, but only an **HTML** one. I
tried `.md` first and checked the result:

```
description elements: 0
item has description: False
```

No warning, no error — it just produces an item with no description. Had I not verified, this would
have been another silent no-op.

So the publish script converts the notes to HTML. Deliberately not a Markdown dependency: these notes
use headings, bullets, links, inline code, bold, emphasis and fenced blocks, and that is a page of
`re.sub` versus a library in the release path.

Paragraphs are **accumulated rather than emitted per line** — the notes are hard-wrapped at 100
columns, and one `<p>` per source line renders as a column of sentence fragments. That was the first
output I got, and it looked wrong immediately.

## Verified end to end

Against the real 1.1.5 notes, using the converter extracted from the script itself rather than a copy:

- well-formed as an XHTML fragment (`ElementTree` parse)
- no DOCTYPE or body tags, so Sparkle embeds it as CDATA rather than linking it
- `generate_appcast` produces an item with a `<description>` starting with the actual first sentence
- headings, `<code>`, `<strong>`, `<em>` and lists all present

`./run-tests.sh` green.