### PR TITLE
Move the workspace state out of /tmp and make it owner-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,10 @@ deepest-first before sealing the bundle, copies with `cp -R` to keep the framewo
 checks that every nested Mach-O is independently signed rather than rejecting nested code outright.
 
 **Workspace memory across a restart**: `WorkspaceMemory.swift` persists window -> workspace, plus
-the monitor each workspace was on, to `/tmp/<bundle-id>-<user>.state.json`.
+the monitor each workspace was on, to `~/Library/Caches/<bundle-id>/workspace-memory.json`, mode
+`0600`. Deliberately not `/tmp` like the CLI socket: the socket is a rendezvous point whose security
+is filesystem permissions on a socket, while this file is *read at startup and acted on*, so one
+planted in a world-writable directory decides where another user's windows go.
 
 > **Both halves, or neither.** A first version restored only the workspace *name* and was reverted:
 > `Workspace.get(byName:)` mints a workspace whose `assignedMonitorPoint` is nil, and the only

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,12 @@ serious, and the config file is the most likely route:
   running as the same user. There is no authentication beyond filesystem permissions, and commands
   arriving on it are executed. This is the same trust model as the config file: same-user processes
   are already trusted.
+- Window placement is remembered across a restart in
+  `~/Library/Caches/<bundle-id>/workspace-memory.json`, mode `0600`, and it is read at startup and
+  acted on. A same-user process can edit it and move windows to a workspace you did not choose --
+  the same trust boundary as the socket and the config. It records bundle ids and monitor UUIDs, and
+  nothing else; a file from another window-server session, or one naming a different app for an id,
+  is discarded rather than applied.
 
 Reports about any of the above are in scope. So are signing, notarization and update-channel
 problems: updates are verified against an EdDSA public key compiled into the app, and a way to make

--- a/Sources/AppBundle/WorkspaceMemory.swift
+++ b/Sources/AppBundle/WorkspaceMemory.swift
@@ -72,7 +72,19 @@ enum WorkspaceMemory {
     /// `ConfigurationWriter`'s do-no-harm invariant must not be dragged into it.
     static var fileUrlOverride: URL?
     static var fileUrl: URL {
-        fileUrlOverride ?? URL(filePath: "/tmp/\(aeroSporkAppId)-\(unixUserName).state.json")
+        if let fileUrlOverride { return fileUrlOverride }
+        // `~/Library/Caches`, not `/tmp`.
+        //
+        // The CLI socket lives in /tmp because it is a rendezvous point two processes have to agree
+        // on, and its security comes from filesystem permissions on a socket. This file is
+        // different in kind: it is read at startup and acted on, so a planted one in a
+        // world-writable directory decides where another user's windows go. Caches is per-user,
+        // still disposable, and still not the config.
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? URL(filePath: NSTemporaryDirectory())
+        let directory = caches.appending(path: aeroSporkAppId, directoryHint: .isDirectory)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appending(path: "workspace-memory.json")
     }
 
     /// WindowServer's pid and start time. Changes on every event that resets the id counter, and on
@@ -265,6 +277,9 @@ enum WorkspaceMemory {
         let work = {
             guard let data = try? JSONEncoder().encode(state) else { return }
             try? data.write(to: url, options: .atomic)
+            // 0600: this names every running app's bundle id and every monitor's UUID. Set after the
+            // write because `.atomic` replaces the file, so any mode set beforehand is discarded.
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
         }
         if waitForCompletion { writeQueue.sync(execute: work) } else { writeQueue.async(execute: work) }
     }

--- a/Sources/AppBundleTests/WorkspaceMemoryTest.swift
+++ b/Sources/AppBundleTests/WorkspaceMemoryTest.swift
@@ -435,6 +435,31 @@ final class WorkspaceMemoryTest: XCTestCase {
         )
     }
 
+    /// The file names every running app's bundle id and every monitor's UUID, and it is read at
+    /// startup and acted on. Owner-only, and out of the world-writable directory the socket uses.
+    func testTheStateFileIsNotReadableByOtherUsers() throws {
+        WorkspaceMemory.load()
+        WorkspaceMemory.save()
+        WorkspaceMemory.waitForWrites()
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: WorkspaceMemory.fileUrl.path)
+        let mode = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber).intValue
+        assertEquals(
+            mode & 0o077, 0,
+            additionalMsg: "state file is group/other-accessible (mode \(String(mode, radix: 8)))",
+        )
+    }
+
+    /// Not in `/tmp`: a file another local user can plant decides where this user's windows go.
+    func testTheDefaultLocationIsNotWorldWritable() {
+        WorkspaceMemory.resetForTests() // clear the test override
+        let path = WorkspaceMemory.fileUrl.path
+        XCTAssertFalse(
+            path.hasPrefix("/tmp/") || path.hasPrefix("/private/tmp/"),
+            "state lives in a world-writable directory: \(path)",
+        )
+    }
+
     // MARK: - The hook
 
     /// The restore is only reachable through `MacWindow.getOrRegister`, which needs a real

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -411,8 +411,8 @@ is what it did before.
 For windows that must land somewhere specific after their app restarts, say so explicitly with
 xref:guide.adoc#on-window-detected-callback[on-window-detected] and `if.during-aerospork-startup`.
 
-The state lives in `/tmp` and is disposable: deleting it costs you one restart's worth of placement
-and nothing else.
+The state lives in `~/Library/Caches/com.wbs.aerospork/workspace-memory.json` and is readable only
+by you. It is disposable: deleting it costs one restart's worth of placement and nothing else.
 
 The name of the active workspace is shown in the menu bar icon.
 


### PR DESCRIPTION
The state file was written to `/tmp` at the default `0644`.

It names every running application's bundle id and every monitor's UUID — nothing another local
account needs to read. And `/tmp` is world-writable, so another user can plant one. That matters more
here than for an ordinary cache: this file is **read at startup and acted on**, so a planted one
decides where your windows go.

**The CLI socket is not a precedent.** A socket in `/tmp` is a rendezvous point two processes must
agree on, and its security is filesystem permissions on the socket itself. This is a file whose
*contents* are trusted. It moves to `~/Library/Caches/<bundle-id>/workspace-memory.json` at `0600` —
still per-user, still disposable, still nowhere near the config.

The mode is set **after** the write: `.atomic` replaces the file, so anything set beforehand goes
away with the temporary it wrote through.

Existing installs leave a stale `/tmp` file behind. It is ignored and can be deleted.

## CI is now a required check

The ruleset already required a pull request and linear history but **not that the tests passed**, so
`CONTRIBUTING.md` described a gate GitHub wasn't enforcing. The check name `test` was confirmed stable
across recent commits before requiring it — a wrong name blocks every merge.

## Tests

Two, both mutation-checked: removing the `chmod` and reverting the path to `/tmp` are each caught.

Docs updated in step — `guide.adoc`, `CLAUDE.md`, and `SECURITY.md` gains the state file in its
trust-model list, which previously enumerated only the socket and the config.

`./run-tests.sh` green.