### PR TITLE
Delete dead code and correct the docs that describe it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /.idea
 /.debug
 /.release
-/.shell-completion
 /.site
 /.man
 # IDK, AppCode randomly creates this EMPTY file. I have no idea what this is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@ aerospork is an i3-like tiling window manager for macOS written in Swift. It use
 ### Debug Build
 ```bash
 ./build-debug.sh              # Build debug version to .debug/
-./run-debug.sh                # Run the debug app (.debug/AeroSpork-Debug.app)
+./run-debug.sh                # Run the debug binary directly (.debug/aerosporkApp)
+./build-debug-app.sh          # Assemble .debug/AeroSpork-Debug.app (needed for Accessibility)
+./launch-debug-app.sh         # Launch that bundle
 ./run-cli.sh [args]           # Run aerospork CLI (forwards args to binary)
 ```
 
@@ -38,7 +40,7 @@ Debug builds use `~/.aerospork-debug.toml` instead of `~/.aerospork.toml` for co
 ```bash
 ./generate.sh                 # Regenerate generated files (*.xcodeproj, *Generated.swift)
 ./build-docs.sh               # Build site and man pages to .site/ and .man/
-./build-shell-completion.sh   # Build shell completion to .shell-completion/
+./build-shell-completion.sh   # Regenerate the vendored completions in shell-completion/
 ```
 
 ## Architecture

--- a/Sources/AppBundle/config/TomlParsingHelpers.swift
+++ b/Sources/AppBundle/config/TomlParsingHelpers.swift
@@ -18,16 +18,6 @@ extension TOMLValueConvertible {
     func expectString(_ backtrace: TomlBacktrace) -> ParsedToml<String> {
         string.orFailure(expectedActualTypeError(expected: .string, actual: type, backtrace))
     }
-
-    /// Validates this value is an integer, returning ParsedToml
-    func expectInt(_ backtrace: TomlBacktrace) -> ParsedToml<Int> {
-        int.orFailure(expectedActualTypeError(expected: .int, actual: type, backtrace))
-    }
-
-    /// Validates this value is a boolean, returning ParsedToml
-    func expectBool(_ backtrace: TomlBacktrace) -> ParsedToml<Bool> {
-        bool.orFailure(expectedActualTypeError(expected: .bool, actual: type, backtrace))
-    }
 }
 
 // MARK: - Error Collection Helpers

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -31,7 +31,7 @@ final class MacApp: AbstractApp {
     /*conforms*/ var execPath: String? { nsApp.executableURL?.path }
     /*conforms*/ var bundlePath: String? { nsApp.bundleURL?.path }
 
-    // todo think if it's possible to integrate this global mutable state to https://github.com/wbsmolen/aerospork/issues/1215
+    // todo think if it's possible to fold this global mutable state into the tree
     //      and make deinitialization automatic in deinit
     @MainActor static var allAppsMap: [pid_t: MacApp] = [:]
     /// Registrations currently in flight. Not private: the tests drive the park/unpark paths of

--- a/Sources/AppBundle/tree/TreeNode.swift
+++ b/Sources/AppBundle/tree/TreeNode.swift
@@ -18,7 +18,7 @@ class TreeNode: Equatable, AeroAny {
     // - move-mouse command
     var lastAppliedLayoutPhysicalRect: Rect? = nil // with real inner gaps
     final var unboundStacktrace: String? = nil
-    var isBound: Bool { parent != nil } // todo drop, once https://github.com/wbsmolen/aerospork/issues/1215 is fixed
+    var isBound: Bool { parent != nil } // todo drop, once unbound nodes are impossible to construct
 
     @MainActor
     init(parent: NonLeafTreeNodeObject, adaptiveWeight: CGFloat, index: Int) {

--- a/Sources/AppBundleTests/tree/TestApp.swift
+++ b/Sources/AppBundleTests/tree/TestApp.swift
@@ -26,10 +26,6 @@ final class TestApp: AbstractApp {
             _windows = newValue
         }
     }
-    @MainActor func detectNewWindowsAndGetIds() async throws -> [UInt32] {
-        return windows.map { $0.windowId }
-    }
-
     private var _focusedWindow: Window? = nil
     var focusedWindow: Window? {
         get { _focusedWindow }

--- a/Sources/Common/util/SequenceEx.swift
+++ b/Sources/Common/util/SequenceEx.swift
@@ -53,10 +53,6 @@ extension Sequence {
         self.min(by: { a, b in selector(a) < selector(b) })
     }
 
-    @inlinable public func maxBy(_ selector: (Self.Element) -> some Comparable) -> Self.Element? {
-        self.max(by: { a, b in selector(a) < selector(b) })
-    }
-
     @inlinable public func sortedBy(_ selector: (Self.Element) -> some Comparable) -> [Self.Element] {
         sorted(by: { a, b in selector(a) < selector(b) })
     }

--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -97,8 +97,8 @@ syspolicy_check distribution .release/AeroSpork.app
 -   `run-debug.sh` - Run the debug app (`.debug/AeroSpork-Debug.app`).
 -   `run-cli.sh` - Run `aerospork` in CLI. Arguments are forwarded to `aerospork` binary.
 -   `build-docs.sh` - Build the site and man pages to `.site` and `.man` dirs respectively.
--   `build-shell-completion.sh` - Build shell completion to `.shell-completion`.
-    You can test that the completion works properly by sourcing the file `source ./.shell-completion/zsh/_aerospork`
+-   `build-shell-completion.sh` - Regenerate the vendored completions in `shell-completion/` (tracked in git).
+    You can test that the completion works properly by sourcing the file `source ./shell-completion/zsh/_aerospork`
 -   `generate.sh` - Regenerate generated project files. `aerospork.xcodeproj` is generated, and some of the source files
     (the source files have `Generated` suffix in their names).
 

--- a/dev-docs/testing-strategy.md
+++ b/dev-docs/testing-strategy.md
@@ -240,7 +240,7 @@ Both are optional but recommended. They convert "parse an unstable debug dump" i
 ## 8. Toolchain selection & preflight (the most-reused skill)
 
 The trap: `script/setup.sh`'s `swift()` wrapper runs `swiftly run swift` and
-`.swift-version` pins `6.2`; on macOS 27 that toolchain is broken and a mismatched SDK
+`.swift-version` pins `6.4`; on macOS 27 that toolchain is broken and a mismatched SDK
 makes `swift build` **hang with no error**.
 
 **Recommendations:**


### PR DESCRIPTION
Housekeeping from the inventory pass. No behaviour change.

## Dead code

Four functions with no callers. `expectInt` and `expectBool` were worse than unused — ints and bools
are parsed by `parseInt`/`parseBool` in the parser table, so these were a **second, competing
vocabulary** the next config key could have been written against. Plus `maxBy`, and a test fake's
`detectNewWindowsAndGetIds`, which is not a protocol requirement.

`assertFail` was reported dead as well. **It has nine callers** — my first check used a glob the shell
never expanded, so every symbol came back "0 callers". Verified properly and left alone.

I also had to redo the deletions: my first attempt walked braces to find each function's extent and
mangled three files — it ate the `@inlinable public` off the *next* declaration, collapsed a `}}`,
and stole a `@MainActor`. Reverted and redone with exact literal blocks; every diff is now a pure
deletion.

## Dead links in shipped source

Two comments linked `aerospork/issues/1215` — an upstream AeroSpace issue number rewritten onto this
fork's URL by the mass rename. This repo has no issues; both 404.

## Doc drift

- Three places pointed at `.shell-completion/`, which is never created. `build-shell-completion.sh`
  writes to `shell-completion/` (tracked in git), and one of the three was a copy-pasteable `source`
  command that fails. The stale `.gitignore` rule goes too.
- `CLAUDE.md` said `run-debug.sh` runs the app bundle. It runs the raw SPM binary; the bundle is built
  and launched by two scripts CLAUDE.md never mentioned — and that distinction governs the
  Accessibility-permission behaviour the same document warns about.
- `testing-strategy.md` said `.swift-version` pins `6.2`. It contains `6.4`, which the same file gets
  right nine lines in.

`./run-tests.sh` green.