### PR TITLE
Make the release tools reachable from the hermetic PATH

### DIFF
--- a/script/publish-release.sh
+++ b/script/publish-release.sh
@@ -42,8 +42,15 @@ repo="wbsmolen/aerospork"
 dist_zip=".release/aerospork-v$build_version.zip"
 sparkle_zip=".release/AeroSpork-$build_version.zip"
 
+# `setup.sh` replaces PATH with `.deps/bin:/bin:/usr/bin` so a build cannot pick up whatever happens
+# to be installed. These three are linked in there alongside the build tools; the check stays because
+# failing here costs nothing and failing after the twenty-minute universal build costs the build.
 for tool in gh swa az; do
-    command -v "$tool" > /dev/null || { echo "Required tool not found: $tool" > /dev/stderr; exit 1; }
+    command -v "$tool" > /dev/null || {
+        echo "Required tool not found: $tool" > /dev/stderr
+        echo "Install it, then re-run: script/setup.sh links it into .deps/bin." > /dev/stderr
+        exit 1
+    }
 done
 
 # The build embeds `git rev-parse HEAD` and then asserts the binary contains it, so a commit landing

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -29,6 +29,9 @@ if /bin/test -z "${NUKE_PATH:-}"; then
     add_optional_dep_to_bin git
     add_optional_dep_to_bin swift
     add_optional_dep_to_bin swiftly
+    add_optional_dep_to_bin gh # publish-release.sh
+    add_optional_dep_to_bin swa # publish-release.sh
+    add_optional_dep_to_bin az # publish-release.sh
 
     export PATH="${PWD}/.deps/bin:/bin:/usr/bin"
     chmod +x .deps/bin/*


### PR DESCRIPTION
`setup.sh` replaces PATH with `.deps/bin:/bin:/usr/bin` so a build cannot pick up whatever happens to be installed, and every tool a script needs is symlinked in. The rewritten publish script calls `gh`, `swa` and `az`, which were not.

Caught by the script's own preflight — which is exactly why that check is there: it failed in two seconds rather than after the twenty-minute universal build. The message now says what to do about it.