### PR TITLE
Publish 1.1.6, and fail the release before the tag rather than after

### DIFF
--- a/script/publish-release.sh
+++ b/script/publish-release.sh
@@ -45,13 +45,24 @@ sparkle_zip=".release/AeroSpork-$build_version.zip"
 # `setup.sh` replaces PATH with `.deps/bin:/bin:/usr/bin` so a build cannot pick up whatever happens
 # to be installed. These three are linked in there alongside the build tools; the check stays because
 # failing here costs nothing and failing after the twenty-minute universal build costs the build.
-for tool in gh swa az; do
+for tool in gh swa az node; do
     command -v "$tool" > /dev/null || {
         echo "Required tool not found: $tool" > /dev/stderr
         echo "Install it, then re-run: script/setup.sh links it into .deps/bin." > /dev/stderr
         exit 1
     }
 done
+
+# The appcast host has to be reachable before anything is published: everything after the tag is
+# irreversible-ish, and discovering the wrong Azure subscription then means a released version that
+# no existing install is offered.
+if ! az staticwebapp show --name aerospork-updates --resource-group aerospork-updates \
+        --query name -o tsv > /dev/null 2>&1; then
+    echo "Cannot reach the aerospork-updates Static Web App." > /dev/stderr
+    echo "Active subscription: '$(az account show --query name -o tsv 2>/dev/null)'." > /dev/stderr
+    echo "The appcast lives in 'billy MCT'; switch with: az account set --subscription <id>" > /dev/stderr
+    exit 1
+fi
 
 # The build embeds `git rev-parse HEAD` and then asserts the binary contains it, so a commit landing
 # mid-build fails the release ~20 minutes in. Refuse up front instead.
@@ -175,10 +186,20 @@ if ! "$sparkle_bin/sign_update" --verify "$published" "$signature" > /dev/null 2
     exit 1
 fi
 
-swa deploy updates-site \
-    --deployment-token "$(az staticwebapp secrets list --name aerospork-updates \
-        --resource-group aerospork-updates --query 'properties.apiKey' -o tsv)" \
-    --env production
+# Resolved before use. `set -e` does not abort on a failure inside `$(...)` when the result is just
+# an argument, so a wrong Azure subscription -- the active one is global CLI state and can be changed
+# by anything else on the machine -- silently produced an empty token and the deploy failed after the
+# release was already public and the tag pushed.
+deployment_token="$(az staticwebapp secrets list --name aerospork-updates \
+    --resource-group aerospork-updates --query 'properties.apiKey' -o tsv)"
+if test -z "$deployment_token"; then
+    echo "!!! Could not read the Static Web App deployment token !!!" > /dev/stderr
+    echo "The active Azure subscription is '$(az account show --query name -o tsv 2>/dev/null)'." > /dev/stderr
+    echo "The appcast lives in 'billy MCT'; switch with: az account set --subscription <id>" > /dev/stderr
+    exit 1
+fi
+
+swa deploy updates-site --deployment-token "$deployment_token" --env production
 
 ################
 ### THE CASK ###

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -32,6 +32,7 @@ if /bin/test -z "${NUKE_PATH:-}"; then
     add_optional_dep_to_bin gh # publish-release.sh
     add_optional_dep_to_bin swa # publish-release.sh
     add_optional_dep_to_bin az # publish-release.sh
+    add_optional_dep_to_bin node # swa, in publish-release.sh
 
     export PATH="${PWD}/.deps/bin:/bin:/usr/bin"
     chmod +x .deps/bin/*

--- a/updates-site/appcast.xml
+++ b/updates-site/appcast.xml
@@ -6,6 +6,47 @@
         <description>Updates for AeroSpork, an i3-like tiling window manager for macOS.</description>
         <language>en</language>
         <item>
+            <title>1.1.6</title>
+            <pubDate>Thu, 30 Jul 2026 17:16:47 -0500</pubDate>
+            <link>https://github.com/wbsmolen/aerospork</link>
+            <sparkle:version>1.1.6</sparkle:version>
+            <sparkle:shortVersionString>1.1.6</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <description><![CDATA[<p>Fixes workspace memory doing nothing after a reboot, a case where editing a window rule could damage unrelated parts of your config, and the missing licence in every previous download.</p>
+<h2>Workspace memory now works on a cold boot</h2>
+<p>1.1.5 remembered which workspace each window was on, but at login it forgot any application that had not finished starting. AeroSpork launches alongside every other login item and macOS&#x27;s own window restore, so a slow app was absent from the first snapshot — and that snapshot was written straight over the memory, deleting its entry before the app ever appeared.</p>
+<p>So the case the feature exists for, restarting your Mac, was the one it skipped. It now waits for those windows instead of forgetting them.</p>
+<p>Also fixed: if a logout was cancelled by another app, AeroSpork kept running with its memory frozen and never saved again for the rest of the session.</p>
+<h2>Editing a window rule could damage unrelated config</h2>
+<p>Three ways, all fixed:</p>
+<ul>
+<li><strong>A regex containing <code>[</code></strong> — an ordinary thing to write in a window-title matcher — silently</li>
+</ul>
+<p>switched off every safety check for the rest of the file. Those checks are what stop the editor rewriting things it cannot represent, including a monitor pinned by hardware fingerprint, so an edit elsewhere could quietly degrade it to a plain name.</p>
+<ul>
+<li><strong>A comment after a section header</strong>, like <code>[on-window] # my rules</code>, made that section</li>
+</ul>
+<p>unrecognisable to the writer. It added a second copy instead of replacing it, so every rule in the table applied twice.</p>
+<ul>
+<li><strong>A monitor written as a list of fallbacks</strong> was reduced to its first entry — including on rows you</li>
+</ul>
+<p>did not touch, since one edit rewrites the whole section. It is now refused with a pointer to the Raw TOML tab rather than silently truncated.</p>
+<h2>The licence was missing from every download</h2>
+<p><code>legal/LICENSE.txt</code> was a link to a file that was never included in the archive, so every release shipped the four third-party licences and not AeroSpork&#x27;s own. The release now carries it, and the packaging refuses to build an archive with a broken link in it.</p>
+<h2>Update notes and the state file</h2>
+<p>The <strong>Check for Updates</strong> dialog showed a blank &quot;what&#x27;s new&quot; pane. It now shows these notes.</p>
+<p>Workspace memory moved from <code>/tmp</code> to <code>~/Library/Caches/com.wbs.aerospork/workspace-memory.json</code> and is readable only by you. It lists which applications are running and which monitors are attached, which no other account on the machine needs to see, and <code>/tmp</code> is writable by anyone — a file planted there decided where your windows went. Upgrading leaves the old file behind; it is ignored and safe to delete.</p>
+<p>Universal (arm64 + x86_64), signed with a Developer ID, notarized and stapled.</p>
+<h2>Install</h2>
+<pre>
+brew install --cask wbsmolen/tap/aerospork
+</pre>
+<p>Or download <code>aerospork-v1.1.6.zip</code>, move <code>aerospork-v1.1.6/AeroSpork.app</code> to <code>/Applications</code>, and grant Accessibility permission when prompted. Optionally put <code>aerospork-v1.1.6/bin/aerospork</code> on your <code>PATH</code> for the CLI.</p>
+<p><code>AeroSpork-1.1.6.zip</code> is the Sparkle update archive — the same app without the CLI, man pages or licence files. It exists for the updater; prefer the versioned zip for a manual install.</p>
+]]></description>
+            <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.6/AeroSpork-1.1.6.zip" length="6310780" type="application/octet-stream" sparkle:edSignature="WGGvT6HkLe+9dCi2XkNDPIYZSAl5mXedoVgI0Juc3tMsfCTUCoXWAuG7Qx49166KHMVlrg9EeOs5QcWZj6hgAg=="/>
+        </item>
+        <item>
             <title>1.1.5</title>
             <pubDate>Thu, 30 Jul 2026 14:18:27 -0500</pubDate>
             <link>https://github.com/wbsmolen/aerospork</link>
@@ -22,15 +63,6 @@
             <sparkle:shortVersionString>1.1.4</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
             <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.4/AeroSpork-1.1.4.zip" length="6250094" type="application/octet-stream" sparkle:edSignature="Gbv8FYEh6gkvwiDd5I4W3PXtPkeqD5AI2znn85hCqmdZlU+jmr9gtdjY5KLheTa6LUD6kMqmtJmBW5m0v6JvCg=="/>
-        </item>
-        <item>
-            <title>1.1.3</title>
-            <pubDate>Thu, 30 Jul 2026 11:23:45 -0500</pubDate>
-            <link>https://github.com/wbsmolen/aerospork</link>
-            <sparkle:version>1.1.3</sparkle:version>
-            <sparkle:shortVersionString>1.1.3</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/wbsmolen/aerospork/releases/download/v1.1.3/AeroSpork-1.1.3.zip" length="6241508" type="application/octet-stream" sparkle:edSignature="CWzb0IrprQyI9Fy1o6H1xyUEy58lfqvdEjVC8HbmOajBA+Ecf+qRkFumXsW3PyFVv1OTf/nNmVwdl1lrQiMzAQ=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
The appcast deploy failed while cutting 1.1.6, **after** the release was public and the tag pushed.

The active Azure subscription is global CLI state — anything else on the machine can change it — and
it had moved, so `az` returned `ResourceGroupNotFound`. `set -e` does not abort on a failure inside
`$(...)` when the result is only an argument, so `az` returning nothing handed `swa` an empty token.
The tap step never ran either.

Two guards:

- **Reachability is checked in the preflight**, before the build and long before the tag. Everything
  after the tag is awkward to undo, and discovering the wrong subscription there means a released
  version no existing install is offered.
- **The token is resolved into a variable and tested**, not interpolated into the command.

Both messages name the subscription the appcast actually lives in — that is the fix, and it is not
guessable from `ResourceGroupNotFound`.

`swa` is a node program and the hermetic PATH has no `node`, which is the second thing this release
tripped over. Linked in beside `gh`/`swa`/`az`.

## The release itself

Both archives published, appcast carries the 1.1.6 item **with release notes embedded** so the update
dialog is no longer blank, signature verified against the asset GitHub serves (and against the wrong
asset as a control), tap at 1.1.6 with a matching sha.

`./run-tests.sh` green.