### PR TITLE
Give aerospork.app a page worth linking, and fix the last dev-doc drift

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -22,7 +22,6 @@ build-site() {
         # Delete "aerospork " prefifx in synopsis
         sed -E -i '' '/tag::synopsis/, /end::synopsis/ s/^(aerospork | {10})//' aerospork*
         bundler exec asciidoctor ./guide.adoc ./commands.adoc ./goodies.adoc
-        cp goodies.html goodness.html # backwards compatibility
         rm -rf ./*.adoc
     cd - > /dev/null
 

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -66,6 +66,27 @@ todo
 
 ../Sources/AppBundle/layout/
 
+## Workspace memory
+
+`WorkspaceMemory.swift` persists window -> workspace, and the monitor each workspace was on, so a
+restart does not scatter the layout. Written to `~/Library/Caches/<bundle-id>/workspace-memory.json`
+at mode `0600`.
+
+Three things about it are load-bearing:
+
+- **Both halves, or neither.** `Workspace.get(byName:)` mints a workspace whose
+  `assignedMonitorPoint` is nil, and the only writers of that field run when a workspace becomes
+  visible or is force-assigned -- so a workspace restored by name alone reports `mainMonitor`, and a
+  multi-monitor layout collapses onto one display. That shipped once and was reverted.
+  `restoredWorkspace(forWindowId:bundleId:)` is the single entry point that does both.
+- **The key is the `CGWindowID` and nothing else.** It comes from a counter owned by WindowServer, so
+  it survives a restart of this process and nothing else. The generation token is WindowServer's pid
+  and start time rather than `kern.boottime`, because the counter restarts on log out and on a
+  graphics fault, neither of which reboots the machine.
+- **Startup adds, never prunes.** At login AeroSpork races every other login item, so an app that has
+  not answered Accessibility yet is absent from the first snapshot; writing that snapshot over the
+  file deletes its entry, and the memory is only consulted while `isStartup`.
+
 ## UI subsystem
 
 ../Sources/AppBundle/ui/

--- a/dev-docs/performance.md
+++ b/dev-docs/performance.md
@@ -170,7 +170,9 @@ AEROSPORK_DEBUG_LOG=1 /Applications/AeroSpork.app/Contents/MacOS/AeroSpork 2>&1 
 ## Known remaining items
 
 - **`model/Monitor.swift`.** `monitors`/`sortedMonitors` rebuild from `NSScreen.screens` on every
-  access; 26 call sites, 4 inside `updateTrayText` alone. **Attempted and deliberately reverted.**
+  access, from around 30 call sites. `updateTrayText` hoists it into a local and reads that, so the
+  hot path costs one rebuild per refresh rather than one per use. **Attempted and deliberately
+  reverted.**
   A `@MainActor` cache cascades isolation into `MonitorEx.monitorId`, `MonitorResolution` and their
   callers (all currently non-isolated); a `nonisolated(unsafe)` cache would be an unsound data
   race. No measurement shows this path is hot, so neither price is justified yet. Profile first.

--- a/dev-docs/testing-strategy.md
+++ b/dev-docs/testing-strategy.md
@@ -34,7 +34,8 @@ headless and reusable:
   (`.debug/aerospork`), `--json` on `list-windows`/`list-workspaces`/`list-monitors`,
   rich `--format` vars, and `trigger-binding`/`enable` for driving the live app.
 - **`run-tests.sh`** already does build → `swift test` → CLI smoke → format/lint →
-  generate → uncommitted-file check. **It is a CI job body with no CI calling it.**
+  generate → uncommitted-file check. `.github/workflows/ci.yml` runs exactly that on every push and pull
+    request, and it is a required status check on `main`.
 
 **The real gaps:**
 
@@ -82,8 +83,12 @@ ships. CI now runs `run-tests.sh` on a hosted `macos-latest` runner.
 
 ## 3. Layer 1 — Unit test gaps (headless, do these first)
 
-All items below have **zero** current coverage (grep-confirmed) unless noted. None need
-a running app. Priority = value × cheapness.
+None of these need a running app. Priority = value × cheapness.
+
+Coverage notes here rot: several rows first written as "zero coverage" have since been covered --
+socket framing by `CommonTests/SocketCodecTest.swift` and `AppBundleTests/model/UnixSocketTest.swift`,
+default-config parsing by `ConfigurationWriterSafetyTest.testShippedDefaultConfigIsEditable`. Check
+before believing a row.
 
 ### P0 — cheap, high-value, no new seam
 
@@ -277,7 +282,8 @@ harness, and the existing scripts (`build-debug-app.sh`,
 1. **Toolchain preflight.** bash, `script/preflight-toolchain.sh`. §8. *Build first.*
 2. ~~**CI workflow.**~~ Done: `.github/workflows/ci.yml` runs `run-tests.sh` on a hosted runner. §9.
 3. **ConfigurationWriter round-trip + fuzz.** XCTest,
-   `Sources/AppBundleTests/config/ConfigurationWriterTest.swift`. §3 P0. *Build first.*
+   Config-writer coverage landed instead across `ConfigTest.swift`,
+   `ConfigurationWriterSafetyTest.swift` and `ConfigSafetyWriterFuzzTest.swift`. *Done.*
 4. **Layout golden-rects.** extend XCTest under `Sources/AppBundleTests/layout/`, golden
    JSON in `.../golden/`. Needs Seam A (§4). Snapshot computed rects for canonical trees
    (h/v split, accordion, nested, 2-monitor); a diff is a layout regression, zero AX.

--- a/updates-site/index.html
+++ b/updates-site/index.html
@@ -1,17 +1,65 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>AeroSpork updates</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AeroSpork — a tiling window manager for macOS</title>
+<meta name="description" content="An i3-like tiling window manager for macOS. Tree layout, workspaces without animation, TOML config, a CLI, and a settings GUI.">
 <style>
-  body{font:15px/1.55 -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
-       max-width:34rem;margin:12vh auto;padding:0 1.5rem;color:#1c202c}
-  code{font:13px ui-monospace,"SF Mono",Menlo,monospace;background:#f2f2f4;padding:.15em .4em;border-radius:4px}
-  a{color:#0064e1}
-  @media (prefers-color-scheme:dark){body{background:#14161c;color:#e6e8ee}code{background:#22262f}}
+  :root { color-scheme: light dark; --fg: #1c202c; --dim: #5b6070; --bg: #fff; --card: #f4f5f7; --link: #0064e1; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg: #e6e8ee; --dim: #9aa0b0; --bg: #14161c; --card: #1e2129; --link: #5e9eff; }
+  }
+  * { box-sizing: border-box }
+  body { font: 16px/1.6 -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+         max-width: 46rem; margin: 0 auto; padding: 5vh 1.5rem 6rem; color: var(--fg); background: var(--bg) }
+  h1 { font-size: 2.1rem; letter-spacing: -.022em; margin: 0 0 .3rem }
+  h2 { font-size: 1.05rem; letter-spacing: -.01em; margin: 2.4rem 0 .6rem }
+  p { margin: 0 0 1rem }
+  .tag { color: var(--dim); font-size: 1.05rem; margin-bottom: 1.8rem }
+  a { color: var(--link); text-decoration: none }
+  a:hover { text-decoration: underline }
+  code, pre { font: 13.5px/1.5 ui-monospace, "SF Mono", Menlo, monospace }
+  code { background: var(--card); padding: .15em .4em; border-radius: 4px }
+  pre { background: var(--card); padding: .9rem 1rem; border-radius: 8px; overflow-x: auto; margin: 0 0 1rem }
+  pre code { background: none; padding: 0 }
+  ul { padding-left: 1.1rem; margin: 0 0 1rem }
+  li { margin-bottom: .35rem }
+  footer { margin-top: 3rem; color: var(--dim); font-size: .9rem }
 </style>
-<h1>AeroSpork updates</h1>
-<p>This host serves the Sparkle appcast for
-<a href="https://github.com/wbsmolen/aerospork">AeroSpork</a>, an i3-like tiling window manager for
-macOS. It is machine-readable infrastructure, not a download page.</p>
-<p>The feed is at <code>/appcast.xml</code>. Updates are signed with an EdDSA key whose public half
-is compiled into the app, so a build refuses any update it cannot verify.</p>
-<p>To install, see the repository.</p>
+
+<h1>AeroSpork</h1>
+<p class="tag">An i3-like tiling window manager for macOS. Windows are leaves of a layout tree,
+workspaces are emulated rather than mapped onto native Spaces, and nothing requires disabling System
+Integrity Protection.</p>
+
+<h2>Install</h2>
+<pre><code>brew install --cask wbsmolen/tap/aerospork</code></pre>
+<p>Or take a notarized build from the
+<a href="https://github.com/wbsmolen/aerospork/releases">releases page</a>, move
+<code>AeroSpork.app</code> to <code>/Applications</code>, and grant Accessibility permission when
+asked. macOS 13 or later, Apple silicon and Intel.</p>
+
+<h2>What you get</h2>
+<ul>
+  <li>Tree layout with tiles and accordion modes, driven from the keyboard or the CLI.</li>
+  <li>Workspaces that switch instantly, because they are emulated rather than animated.</li>
+  <li>Monitors matched by hardware UUID, so a workspace stays on the same physical panel across a
+      redock — including DisplayLink displays, which report no EDID at all.</li>
+  <li>Windows return to the workspace they were on when AeroSpork restarts.</li>
+  <li>Plain-text TOML configuration, with a settings GUI that edits it without touching your
+      comments.</li>
+</ul>
+
+<h2>Documentation</h2>
+<p><a href="https://github.com/wbsmolen/aerospork/blob/main/docs/guide.adoc">The guide</a> covers
+configuration and troubleshooting;
+<a href="https://github.com/wbsmolen/aerospork/blob/main/docs/commands.adoc">the command reference</a>
+covers all 37 CLI commands, which are also installed as man pages. The
+<a href="https://github.com/wbsmolen/aerospork">repository</a> explains how this fork differs from
+<a href="https://github.com/nikitabobko/AeroSpace">AeroSpace</a>, which it is built on.</p>
+
+<footer>
+  <p>Installed copies check <code>/appcast.xml</code> on this host for updates. Each one is signed
+  with an EdDSA key whose public half ships in the app, and a build refuses any update it cannot
+  verify.</p>
+  <p>MIT licensed. A fork of AeroSpace by Nikita Bobko.</p>
+</footer>


### PR DESCRIPTION
The domain served a placeholder saying it was *"machine-readable infrastructure, not a download page"*
and telling visitors to go to GitHub — so setting it as the repo homepage sent people in a circle.

It is now a landing page: the install line, what the thing does, links into the guide and command
reference. Every claim checked against the code (37 commands, macOS 13, the cask path resolves). It
also repeated the "key compiled into the app" error, wrong the same way the README and SECURITY.md
were.

**The appcast shares that directory**, so it rides along on the deploy and was verified immediately:
`/appcast.xml` still 200s at 1.1.6, and so does the legacy Azure hostname 1.1.0 copies poll.

Homepage now points there. **Dependabot security updates enabled** — Sparkle is in the update trust
path and both dependencies are pinned exactly, so nothing would otherwise warn on an advisory.

## dev-doc corrections

Each checked rather than assumed:

- `testing-strategy.md` said `run-tests.sh` is *"a CI job body with no CI calling it"*. `ci.yml` runs
  exactly that, and it is now a **required** status check.
- It said every listed gap has zero coverage. Two are covered — socket framing and default-config
  parsing. The row now says coverage notes rot, and to check first.
- It listed a `ConfigurationWriterTest.swift` to *"build first"*. That work landed across three other
  files.
- `performance.md` counted four `sortedMonitors` accesses inside `updateTrayText`. It hoists into a
  local and reads that, so the hot path rebuilds once per refresh, not four times.
- `architecture.md` had no `WorkspaceMemory` section — where a contributor would look for the three
  things about it that are easy to get wrong, all of which have already been got wrong once.

`build-docs.sh` copied `goodies.html` to `goodness.html` for "backwards compatibility" with an
upstream site this fork has never had.

`./run-tests.sh` green, docs build clean, 38 man pages.